### PR TITLE
feat: cost model cardinality estimation for TPC-H queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/
 .DS_Store
 
 optd-persistent/sql/
+optd_perfbench_workspace/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,6 +2408,7 @@ dependencies = [
  "optd-cost-model",
  "optd-persistent",
  "ordered-float 4.5.0",
+ "paste",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +149,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
+name = "apache-avro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
+dependencies = [
+ "bzip2",
+ "crc32fast",
+ "digest",
+ "lazy_static",
+ "libflate",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "snap",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "thiserror",
+ "typed-builder",
+ "uuid",
+ "xz2",
+ "zstd 0.12.4",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,7 +211,7 @@ dependencies = [
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "arrow-string",
 ]
@@ -185,7 +225,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "half",
  "num",
@@ -200,7 +240,7 @@ dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half",
@@ -228,7 +268,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "chrono",
  "comfy-table",
@@ -247,7 +287,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -263,7 +303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475a4c3699c8b4095ca61cecf15da6f67841847a5f5aac983ccb9a377d02f73a"
 dependencies = [
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "half",
  "num",
 ]
@@ -278,7 +318,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "flatbuffers",
 ]
 
@@ -292,7 +332,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.6.0",
@@ -311,7 +351,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "half",
  "num",
@@ -327,7 +367,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "half",
  "hashbrown 0.14.5",
 ]
@@ -337,12 +377,9 @@ name = "arrow-schema"
 version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d179c117b158853e0101bfbed5615e86fe97ee356b4af901f1c5001e1ce4b"
-
-[[package]]
-name = "arrow-schema"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539ada65246b949bd99ffa0881a9a15a4a529448af1a07a9838dd78617dafab1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "arrow-select"
@@ -354,7 +391,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "num",
 ]
 
@@ -367,12 +404,17 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "num",
  "regex",
  "regex-syntax 0.7.5",
 ]
+
+[[package]]
+name = "arrow-tools"
+version = "0.18.0"
+source = "git+https://github.com/wangpatrick57/arrow-tools.git?branch=main#c04460346d808268e7811b212212c3442428330c"
 
 [[package]]
 name = "assert_approx_eq"
@@ -821,6 +863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +998,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv2parquet"
+version = "0.18.0"
+source = "git+https://github.com/wangpatrick57/arrow-tools.git?branch=main#c04460346d808268e7811b212212c3442428330c"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "arrow-tools",
+ "clap",
+ "parquet",
+ "regex",
+ "serde_json",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,9 +1072,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7014432223f4d721cb9786cd88bb89e7464e0ba984d4a7f49db7787f5f268674"
 dependencies = [
  "ahash 0.8.11",
+ "apache-avro",
  "arrow",
  "arrow-array",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1025,6 +1097,7 @@ dependencies = [
  "indexmap 2.6.0",
  "itertools 0.11.0",
  "log",
+ "num-traits",
  "num_cpus",
  "object_store",
  "parking_lot",
@@ -1049,10 +1122,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3903ed8f102892f17b48efa437f3542159241d41c564f0d1e78efdc5e663aa"
 dependencies = [
  "ahash 0.8.11",
+ "apache-avro",
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "half",
  "num_cpus",
@@ -1125,7 +1199,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "base64 0.21.7",
  "blake2",
  "blake3",
@@ -1159,7 +1233,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1187,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b568d44c87ead99604d704f942e257c8a236ee1bbf890ee3e034ad659dcb2c21"
 dependencies = [
  "arrow",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -1257,6 +1331,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1940,6 +2037,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2186,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "murmur2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb585ade2549a017db2e35978b77c319214fa4b37cede841e27954dd6e8f3ca8"
 
 [[package]]
 name = "nom"
@@ -2244,23 +2371,48 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 name = "optd-cost-model"
 version = "0.1.0"
 dependencies = [
- "arrow-schema 53.2.0",
+ "anyhow",
+ "arrow-schema",
  "assert_approx_eq",
  "async-trait",
  "chrono",
  "crossbeam",
  "datafusion",
  "datafusion-expr",
+ "hashbrown 0.14.5",
  "itertools 0.13.0",
+ "murmur2",
  "optd-persistent",
  "ordered-float 4.5.0",
  "rand",
+ "rayon",
  "serde",
  "serde_json",
  "serde_with",
  "test-case",
  "tokio",
  "trait-variant",
+]
+
+[[package]]
+name = "optd-cost-model-perf"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "csv2parquet",
+ "datafusion",
+ "datafusion-expr",
+ "env_logger",
+ "log",
+ "optd-cost-model",
+ "optd-persistent",
+ "ordered-float 4.5.0",
+ "rayon",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
 ]
 
 [[package]]
@@ -2371,7 +2523,7 @@ dependencies = [
  "arrow-cast",
  "arrow-data",
  "arrow-ipc",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "base64 0.21.7",
  "brotli",
@@ -2599,6 +2751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2802,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2861,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -2754,6 +2938,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rsa"
@@ -3920,6 +4110,26 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["optd-cost-model", "optd-persistent"]
+members = ["optd-cost-model", "optd-persistent", "optd-cost-model-perf"]
 resolver = "2"

--- a/optd-cost-model-perf/Cargo.toml
+++ b/optd-cost-model-perf/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "optd-cost-model-perf"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+optd-cost-model = { path = "../optd-cost-model", features = ["include-tests"] }
+optd-persistent = { path = "../optd-persistent" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+datafusion-expr = "32.0.0"
+csv2parquet = { git = "https://github.com/wangpatrick57/arrow-tools.git", branch = "main" }
+log = "0.4"
+datafusion = { version = "32.0.0", features = [
+    "avro",
+    "crypto_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "unicode_expressions",
+    "compression",
+] }
+shlex = "1.3"
+ordered-float = "4.0"
+tokio = { version = "1.0.1", features = ["macros", "rt-multi-thread"] }
+anyhow = "1.0"
+rayon = "1.10"
+clap = { version = "4.5.4", features = ["derive"] }
+env_logger = "0.11"

--- a/optd-cost-model-perf/Cargo.toml
+++ b/optd-cost-model-perf/Cargo.toml
@@ -26,3 +26,4 @@ anyhow = "1.0"
 rayon = "1.10"
 clap = { version = "4.5.4", features = ["derive"] }
 env_logger = "0.11"
+paste = "1.0"

--- a/optd-cost-model-perf/src/dbms.rs
+++ b/optd-cost-model-perf/src/dbms.rs
@@ -1,0 +1,250 @@
+use datafusion::{
+    arrow::util::display::{ArrayFormatter, FormatOptions},
+    common::sql_err,
+    error::DataFusionError,
+    execution::{
+        context::SessionState,
+        runtime_env::{RuntimeConfig, RuntimeEnv},
+    },
+    parquet::arrow::arrow_reader::{
+        ArrowReaderMetadata, ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder,
+    },
+    prelude::{SessionConfig, SessionContext},
+    sql::{
+        parser::DFParser,
+        sqlparser::{dialect::GenericDialect, parser::ParserError},
+    },
+};
+use optd_cost_model::{
+    common::types::TableId,
+    storage::mock::{BaseTableStats, TableStats},
+};
+use rayon::prelude::*;
+
+pub type DataFusionBaseTableStats = BaseTableStats;
+pub type DataFusionPerTableStats = TableStats;
+
+use crate::tpch::{TpchKit, TpchKitConfig};
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+pub struct DatafusionDBMS {
+    workspace_dpath: PathBuf,
+}
+
+const WITH_LOGICAL_FOR_TPCH: bool = true;
+
+impl DatafusionDBMS {
+    pub async fn new<P: AsRef<Path>>(workspace_dpath: P) -> anyhow::Result<Self> {
+        Ok(DatafusionDBMS {
+            workspace_dpath: workspace_dpath.as_ref().to_path_buf(),
+        })
+    }
+
+    async fn new_session_ctx(use_df_logical: bool) -> anyhow::Result<SessionContext> {
+        let mut session_config = SessionConfig::from_env()?.with_information_schema(true);
+
+        if !use_df_logical {
+            session_config.options_mut().optimizer.max_passes = 0;
+        }
+
+        let rn_config = RuntimeConfig::new();
+        let runtime_env = RuntimeEnv::new(rn_config.clone())?;
+        let ctx = {
+            let state =
+                SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
+            SessionContext::new_with_state(state)
+        };
+        ctx.refresh_catalogs().await?;
+        Ok(ctx)
+    }
+
+    async fn execute(ctx: &SessionContext, sql: &str) -> anyhow::Result<Vec<Vec<String>>> {
+        let sql = unescape_input(sql)?;
+        let dialect = Box::new(GenericDialect);
+        let statements = DFParser::parse_sql_with_dialect(&sql, dialect.as_ref())?;
+        let mut result = Vec::new();
+        for statement in statements {
+            let df = {
+                let plan = ctx.state().statement_to_plan(statement).await?;
+                ctx.execute_logical_plan(plan).await?
+            };
+
+            let batches = df.collect().await?;
+
+            let options = FormatOptions::default();
+
+            for batch in batches {
+                let converters = batch
+                    .columns()
+                    .iter()
+                    .map(|a| ArrayFormatter::try_new(a.as_ref(), &options))
+                    .collect::<Result<Vec<_>, _>>()?;
+                for row_idx in 0..batch.num_rows() {
+                    let mut row = Vec::with_capacity(batch.num_columns());
+                    for converter in converters.iter() {
+                        let mut buffer = String::with_capacity(8);
+                        converter.value(row_idx).write(&mut buffer)?;
+                        row.push(buffer);
+                    }
+                    result.push(row);
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    async fn create_tpch_tables(ctx: &SessionContext, tpch_kit: &TpchKit) -> anyhow::Result<()> {
+        let ddls = fs::read_to_string(&tpch_kit.schema_fpath)?;
+        let ddls = ddls
+            .split(';')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+        for ddl in ddls {
+            Self::execute(ctx, ddl).await?;
+        }
+        Ok(())
+    }
+
+    fn build_batch_reader(
+        tbl_fpath: PathBuf,
+        num_row_groups: usize,
+    ) -> impl FnOnce() -> Vec<ParquetRecordBatchReader> {
+        move || {
+            let groups: Vec<ParquetRecordBatchReader> = (0..num_row_groups)
+                .map(|group_num| {
+                    let tbl_file = File::open(tbl_fpath.clone()).expect("Failed to open file");
+                    let metadata =
+                        ArrowReaderMetadata::load(&tbl_file, Default::default()).unwrap();
+
+                    ParquetRecordBatchReaderBuilder::new_with_metadata(
+                        tbl_file.try_clone().unwrap(),
+                        metadata.clone(),
+                    )
+                    .with_row_groups(vec![group_num])
+                    .build()
+                    .unwrap()
+                })
+                .collect();
+
+            groups
+        }
+    }
+
+    /// Need to guarantee that each table has a unique ID.
+    fn gen_table_id(tbl_paths: Vec<PathBuf>) -> HashMap<String, TableId> {
+        let mut tbl_id = 0;
+        let mut tbl_id_map = HashMap::new();
+        for tbl_fpath in tbl_paths {
+            let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
+            tbl_id_map.insert(tbl_name.to_string(), TableId(tbl_id));
+            println!("Table {:?} has ID {:?}", tbl_name, tbl_id);
+            tbl_id += 1;
+        }
+        tbl_id_map
+    }
+
+    fn gen_base_stats(tbl_paths: Vec<PathBuf>) -> anyhow::Result<DataFusionBaseTableStats> {
+        let base_table_stats = Mutex::new(DataFusionBaseTableStats::default());
+        let tbl_id_map = Self::gen_table_id(tbl_paths.clone());
+        let now = Instant::now();
+
+        tbl_paths.par_iter().for_each(|tbl_fpath| {
+            let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(tbl_fpath);
+            let start = Instant::now();
+
+            // We get the schema from the Parquet file, to ensure there's no divergence between
+            // the context and the file we are going to read.
+            // Further rounds of refactoring should adapt the entry point of stat gen.
+            let tbl_file = File::open(tbl_fpath).expect("Failed to open file");
+            let parquet =
+                ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap()).unwrap();
+            let schema = parquet.schema();
+            // println!("Table {:?} schema: {:#?}", tbl_name, schema);
+
+            let nb_cols = schema.fields().len();
+            let single_cols = (0..nb_cols).map(|v| vec![v]).collect::<Vec<_>>();
+
+            let stats_result = DataFusionPerTableStats::from_record_batches(
+                Self::build_batch_reader(tbl_fpath.clone(), parquet.metadata().num_row_groups()),
+                Self::build_batch_reader(tbl_fpath.clone(), parquet.metadata().num_row_groups()),
+                single_cols,
+                schema.clone(),
+            );
+
+            if let Ok(per_table_stats) = stats_result {
+                let mut stats = base_table_stats.lock().unwrap();
+                stats.insert(tbl_id_map[&tbl_name], per_table_stats);
+            }
+
+            println!(
+                "Table {:?} took in total {:?}...",
+                tbl_name,
+                start.elapsed()
+            );
+        });
+
+        println!("Total execution time {:?}...", now.elapsed());
+
+        let stats = base_table_stats.into_inner();
+        let l = stats.unwrap();
+        Ok(l)
+    }
+
+    pub async fn get_tpch_stats(
+        &mut self,
+        tpch_kit_config: &TpchKitConfig,
+    ) -> anyhow::Result<DataFusionBaseTableStats> {
+        // Create tables in a temporary context to get the schema provider.
+        let ctx = Self::new_session_ctx(WITH_LOGICAL_FOR_TPCH).await?;
+        let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
+        Self::create_tpch_tables(&ctx, &tpch_kit).await?;
+        let schema_provider = ctx.catalog("datafusion").unwrap().schema("public").unwrap();
+
+        // Generate the tables
+        tpch_kit.gen_tables(tpch_kit_config)?;
+        tpch_kit
+            .make_parquet_files(tpch_kit_config, schema_provider)
+            .await?;
+        // Compute base statistics on Parquet.
+        let tbl_paths = tpch_kit.get_tbl_fpath_vec(tpch_kit_config, "parquet")?;
+        assert!(tbl_paths.len() == tpch_kit.get_tbl_fpath_vec(tpch_kit_config, "tbl")?.len());
+        Self::gen_base_stats(tbl_paths)
+    }
+}
+
+pub fn unescape_input(input: &str) -> datafusion::error::Result<String> {
+    let mut chars = input.chars();
+
+    let mut result = String::with_capacity(input.len());
+    while let Some(char) = chars.next() {
+        if char == '\\' {
+            if let Some(next_char) = chars.next() {
+                // https://static.rust-lang.org/doc/master/reference.html#literals
+                result.push(match next_char {
+                    '0' => '\0',
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    '\\' => '\\',
+                    _ => {
+                        return sql_err!(ParserError::TokenizerError(format!(
+                            "unsupported escape char: '\\{}'",
+                            next_char
+                        ),))
+                    }
+                });
+            }
+        } else {
+            result.push(char);
+        }
+    }
+
+    Ok(result)
+}

--- a/optd-cost-model-perf/src/lib.rs
+++ b/optd-cost-model-perf/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod dbms;
 pub mod shell;
 pub mod tpch;
-pub mod tpch_q6;

--- a/optd-cost-model-perf/src/lib.rs
+++ b/optd-cost-model-perf/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod dbms;
+pub mod shell;
+pub mod tpch;
+pub mod tpch_q6;

--- a/optd-cost-model-perf/src/main.rs
+++ b/optd-cost-model-perf/src/main.rs
@@ -1,0 +1,174 @@
+use clap::Parser;
+use clap::Subcommand;
+use optd_cost_model::common::types::GroupId;
+use optd_cost_model::common::types::TableId;
+use optd_cost_model::stats::AttributeCombValueStats;
+use optd_cost_model::test_utils::tests::create_mock_cost_model_with_memo;
+use optd_cost_model::test_utils::tests::MemoGroupInfo;
+use optd_cost_model::{CostModel, EstimatedStatistic};
+use optd_cost_model_perf::dbms::DataFusionBaseTableStats;
+use optd_cost_model_perf::dbms::DatafusionDBMS;
+use optd_cost_model_perf::shell;
+use optd_cost_model_perf::tpch::TpchKitConfig;
+use optd_cost_model_perf::tpch::TPCH_KIT_POSTGRES;
+use optd_cost_model_perf::tpch_q6::init_tpch_q6;
+use optd_cost_model_perf::tpch_q6::OperatorNode;
+use std::collections::HashMap;
+use std::fs;
+
+const TPCH_QUERIES: &[&str] = &["6"];
+
+#[derive(Parser)]
+struct Cli {
+    #[clap(long)]
+    #[clap(default_value = "optd_perfbench_workspace")]
+    #[clap(
+        help = "The directory where artifacts required for performance testing (such as pgdata or TPC-H queries) are generated. See comment of parse_pathstr() to see what paths are allowed (TLDR: absolute and relative both ok)."
+    )]
+    workspace: String,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Cardbench {
+        #[clap(long)]
+        #[clap(default_value = "0.01")]
+        scale_factor: f64,
+
+        #[clap(long)]
+        #[clap(default_value = "15721")]
+        seed: i32,
+
+        #[clap(long)]
+        #[clap(value_delimiter = ',', num_args = 1..)]
+        // This is the current list of all queries that work in perfbench
+        #[clap(default_value = None)]
+        #[clap(help = "The queries to get the Q-error of")]
+        query_ids: Vec<String>,
+        // #[clap(long)]
+        // #[clap(default_value = "default_user")]
+        // #[clap(help = "The name of a user with superuser privileges")]
+        // pguser: String,
+
+        // #[clap(long)]
+        // #[clap(default_value = "password")]
+        // #[clap(help = "The name of a user with superuser privileges")]
+        // pgpassword: String,
+    },
+}
+
+/// We can only handle single attribute stats for now.
+/// TODO: is this true??
+fn get_single_attr_stats(
+    column_comb_stats: HashMap<Vec<u64>, AttributeCombValueStats>,
+) -> HashMap<u64, AttributeCombValueStats> {
+    let mut single_attr_stats = HashMap::new();
+    for (column_comb, comb_stats) in column_comb_stats {
+        if column_comb.len() == 1 {
+            single_attr_stats.insert(column_comb[0], comb_stats);
+        }
+    }
+    single_attr_stats
+}
+
+/// Compute the estimated statistics for a query.
+/// WARNING: This is a VERY naive approach. It assumes that the plan nodes form a linear tree, which is not true in general.
+/// However, this assumption is valid for TPC-H Q6.
+/// TODO: post-order traversal of the plan tree.
+async fn compute_stats(
+    table_ids: Vec<TableId>,
+    memo: HashMap<GroupId, MemoGroupInfo>,
+    operator_nodes: Vec<OperatorNode>,
+    base_stats: DataFusionBaseTableStats,
+) -> EstimatedStatistic {
+    let mut per_attribute_stats = vec![];
+    let mut row_counts = vec![];
+    for table_id in &table_ids {
+        let table_stats = &base_stats[&table_id];
+        per_attribute_stats.push(get_single_attr_stats(table_stats.column_comb_stats.clone()));
+        row_counts.push(Some(table_stats.row_cnt));
+    }
+    let cost_model = create_mock_cost_model_with_memo(
+        table_ids.clone(),
+        per_attribute_stats,
+        row_counts,
+        memo.into(),
+    );
+    let mut children_stats = EstimatedStatistic(-1.0);
+    for mut operator_node in operator_nodes {
+        if children_stats != EstimatedStatistic(-1.0) {
+            operator_node.children_stats.push(children_stats);
+        }
+        let stats = cost_model
+            .derive_statistics(
+                operator_node.typ,
+                &operator_node.predicates,
+                &operator_node.children_stats,
+                operator_node.context,
+            )
+            .await
+            .unwrap();
+        println!(
+            "Estimated cardinality for {:?}: {}",
+            operator_node.typ, stats.0
+        );
+        children_stats = stats;
+    }
+    children_stats
+}
+
+/// TPC-H
+///
+/// | Table Name | ID |
+/// |------------|----|
+/// | part       | 0  |
+/// | region     | 1  |
+/// | supplier   | 2  |
+/// | orders     | 3  |
+/// | nation     | 4  |
+/// | lineitem   | 5  |
+/// | partsupp   | 6  |
+/// | customer   | 7  |
+///
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+
+    let workspace_dpath = shell::parse_pathstr(&cli.workspace)?;
+    if !workspace_dpath.exists() {
+        fs::create_dir(&workspace_dpath)?;
+    }
+
+    match cli.command {
+        Commands::Cardbench {
+            scale_factor,
+            seed,
+            query_ids,
+            // pguser,
+            // pgpassword,
+        } => {
+            let query_ids = if query_ids.is_empty() {
+                TPCH_QUERIES.iter().map(|s| s.to_string()).collect()
+            } else {
+                query_ids
+            };
+            // let pgdata_dpath = workspace_dpath.join("pgdata");
+            let mut dbms = Box::new(DatafusionDBMS::new(&workspace_dpath).await?);
+            let tpch_kit_config = TpchKitConfig {
+                dbms: String::from(TPCH_KIT_POSTGRES),
+                scale_factor,
+                seed,
+                query_ids: query_ids.clone(),
+            };
+            let base_stats = dbms.get_tpch_stats(&tpch_kit_config).await?;
+            let (table_ids, memo, operator_nodes) = init_tpch_q6();
+            let stats = compute_stats(table_ids, memo, operator_nodes, base_stats).await;
+            println!("Estimated cardinality: {}", stats.0);
+            Ok(())
+        }
+    }
+}

--- a/optd-cost-model-perf/src/main.rs
+++ b/optd-cost-model-perf/src/main.rs
@@ -11,6 +11,7 @@ use optd_cost_model_perf::dbms::DatafusionDBMS;
 use optd_cost_model_perf::shell;
 use optd_cost_model_perf::tpch::q2::init_tpch_q2;
 use optd_cost_model_perf::tpch::q6::init_tpch_q6;
+use optd_cost_model_perf::tpch::q7::init_tpch_q7;
 use optd_cost_model_perf::tpch::q8::init_tpch_q8;
 use optd_cost_model_perf::tpch::q9::init_tpch_q9;
 use optd_cost_model_perf::tpch::OperatorNode;
@@ -28,7 +29,7 @@ use optd_cost_model_perf::tpch::TPCH_KIT_POSTGRES;
 use std::collections::HashMap;
 use std::fs;
 
-const TPCH_QUERIES: &[&str] = &["2", "6", "8", "9"];
+const TPCH_QUERIES: &[&str] = &["2", "6", "7", "8", "9"];
 
 #[derive(Parser)]
 struct Cli {
@@ -138,10 +139,10 @@ async fn compute_stats(
             )
             .await
             .unwrap();
-        // println!(
-        //     "Estimated cardinality for {:?}: {}",
-        //     operator_node.typ, stats.0
-        // );
+        println!(
+            "Estimated cardinality for {:?}: {}",
+            operator_node.typ, stats.0
+        );
         derived_stats.insert(operator_node.context.group_id, stats);
     }
 
@@ -185,6 +186,7 @@ async fn main() -> anyhow::Result<()> {
                 let (memo, operator_nodes) = match query_id.as_str() {
                     "2" => init_tpch_q2(),
                     "6" => init_tpch_q6(),
+                    "7" => init_tpch_q7(),
                     "8" => init_tpch_q8(),
                     "9" => init_tpch_q9(),
                     _ => {

--- a/optd-cost-model-perf/src/main.rs
+++ b/optd-cost-model-perf/src/main.rs
@@ -9,10 +9,11 @@ use optd_cost_model::{CostModel, EstimatedStatistic};
 use optd_cost_model_perf::dbms::DataFusionBaseTableStats;
 use optd_cost_model_perf::dbms::DatafusionDBMS;
 use optd_cost_model_perf::shell;
+use optd_cost_model_perf::tpch::q6::init_tpch_q6;
+use optd_cost_model_perf::tpch::OperatorNode;
 use optd_cost_model_perf::tpch::TpchKitConfig;
 use optd_cost_model_perf::tpch::TPCH_KIT_POSTGRES;
-use optd_cost_model_perf::tpch_q6::init_tpch_q6;
-use optd_cost_model_perf::tpch_q6::OperatorNode;
+
 use std::collections::HashMap;
 use std::fs;
 
@@ -120,19 +121,6 @@ async fn compute_stats(
     children_stats
 }
 
-/// TPC-H
-///
-/// | Table Name | ID |
-/// |------------|----|
-/// | part       | 0  |
-/// | region     | 1  |
-/// | supplier   | 2  |
-/// | orders     | 3  |
-/// | nation     | 4  |
-/// | lineitem   | 5  |
-/// | partsupp   | 6  |
-/// | customer   | 7  |
-///
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();

--- a/optd-cost-model-perf/src/shell.rs
+++ b/optd-cost-model-perf/src/shell.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::{fs, io, str};
+
+/// Runs a command, exiting the program immediately if the command fails
+pub fn run_command_with_status_check(cmd_str: &str) -> io::Result<Output> {
+    // we need to bind it to some arbitrary type that implements AsRef<Path>. I just chose &Path
+    run_command_with_status_check_core::<&Path>(cmd_str, None)
+}
+
+/// Runs a command in a directory, exiting the program immediately if the command fails
+pub fn run_command_with_status_check_in_dir<P: AsRef<Path>>(
+    cmd_str: &str,
+    in_path: P,
+) -> io::Result<Output> {
+    run_command_with_status_check_core::<P>(cmd_str, Some(in_path))
+}
+
+/// This function exposes all the different ways to run a command, but the interface is not
+/// ergonomic. The ergonomic wrappers above are a workaround for Rust not having default values on
+/// parameters.
+pub fn run_command_with_status_check_core<P: AsRef<Path>>(
+    cmd_str: &str,
+    in_path: Option<P>,
+) -> io::Result<Output> {
+    // use shlex::split() instead of split_whitespace() to handle cases like quotes and escape chars
+    let mut cmd_components: Vec<String> = shlex::split(cmd_str).unwrap();
+    let cmd_name = cmd_components.remove(0);
+    let args = cmd_components;
+    let mut cmd = Command::new(cmd_name);
+    cmd.args(args);
+    if let Some(in_path) = in_path {
+        cmd.current_dir(in_path);
+    }
+    let output = cmd.output()?;
+
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "```{}``` failed with ```{}```",
+                cmd_str,
+                String::from_utf8_lossy(&output.stderr)
+            )
+            .as_str(),
+        ))
+    }
+}
+
+/// Make dpath an existent but empty directory.
+pub fn make_into_empty_dir<P>(dpath: P) -> io::Result<()>
+where
+    P: AsRef<Path>,
+{
+    if dpath.as_ref().exists() {
+        fs::remove_dir_all(&dpath)?;
+    }
+    if !dpath.as_ref().exists() {
+        fs::create_dir(&dpath)?;
+    }
+    Ok(())
+}
+
+/// Get the path of the root "optd" repo directory
+pub fn get_optd_root() -> io::Result<PathBuf> {
+    let url_output = run_command_with_status_check("git config --get remote.origin.url")?;
+    let url_string = str::from_utf8(&url_output.stdout).unwrap().trim();
+    assert!(
+        url_string.contains("cmu-db/optd"),
+        "You are in the repo with url_string={}. This was not recognized as the optd repo.",
+        url_string
+    );
+    let toplevel_output = run_command_with_status_check("git rev-parse --show-toplevel")?;
+    let toplevel_str = str::from_utf8(&toplevel_output.stdout).unwrap().trim();
+    let toplevel_dpath = PathBuf::from(toplevel_str);
+    Ok(toplevel_dpath)
+}
+
+/// Can be an absolute path or a relative path. Regardless of where this CLI is run, relative paths
+/// are evaluated relative to the optd repo root.
+pub fn parse_pathstr(pathstr: &str) -> io::Result<PathBuf> {
+    let path = PathBuf::from(pathstr);
+    let path = if path.is_relative() {
+        get_optd_root()?.join(path)
+    } else {
+        path
+    };
+    Ok(path)
+}
+
+/// Get a repo to its latest state by either cloning or pulling
+pub fn clonepull_repo<P: AsRef<Path>>(repo_url: &str, repo_dpath: P) -> io::Result<()> {
+    if !repo_dpath.as_ref().exists() {
+        log::debug!("[start] cloning {} repo", repo_url);
+        run_command_with_status_check(&format!(
+            "git clone {} {}",
+            repo_url,
+            repo_dpath.as_ref().to_str().unwrap()
+        ))?;
+        log::debug!("[end] cloning {} repo", repo_url);
+    } else {
+        log::debug!("[skip] cloning {} repo", repo_url);
+    }
+    log::debug!("[start] pulling latest {} repo", repo_url);
+    run_command_with_status_check_in_dir("git pull", &repo_dpath)?;
+    log::debug!("[end] pulling latest {} repo", repo_url);
+    // make sure to do this so that get_optd_root() doesn't break
+    Ok(())
+}

--- a/optd-cost-model-perf/src/tpch.rs
+++ b/optd-cost-model-perf/src/tpch.rs
@@ -1,0 +1,287 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use std::env::consts::OS;
+use std::fmt::{self, Display, Formatter};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{env, fs, io};
+
+/// A wrapper around tpch-kit
+use csv2parquet::Opts;
+use datafusion::catalog::schema::SchemaProvider;
+use serde::{Deserialize, Serialize};
+
+use crate::shell;
+
+const TPCH_KIT_REPO_URL: &str = "https://github.com/wangpatrick57/tpch-kit.git";
+pub const TPCH_KIT_POSTGRES: &str = "POSTGRESQL";
+const NUM_TPCH_QUERIES: usize = 22;
+pub const WORKING_QUERY_IDS: &[&str] = &["6"];
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TpchKitConfig {
+    pub dbms: String,
+    pub scale_factor: f64,
+    pub seed: i32,
+    pub query_ids: Vec<String>,
+}
+
+impl Display for TpchKitConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Use write! macro to write formatted string to `f`
+        write!(
+            f,
+            "TpchKitConfig(dbms={}, scale_factor={}, seed={}, query_ids={:?})",
+            self.dbms, self.scale_factor, self.seed, self.query_ids
+        )
+    }
+}
+
+/// Provides many helper functions for running a TPC-H workload.
+/// It does not actually execute the queries as it is meant to be DBMS-agnostic.
+/// Is essentially a wrapper around the tpch-kit repo.
+/// Since it's conceptually a wrapper around the repo, I chose _not_ to make
+///   TpchKitConfig an initialization parameter.
+pub struct TpchKit {
+    _workspace_dpath: PathBuf,
+
+    // cache these paths so we don't have to build them multiple times
+    _tpch_dpath: PathBuf,
+    tpch_kit_repo_dpath: PathBuf,
+    queries_dpath: PathBuf,
+    dbgen_dpath: PathBuf,
+    genned_tables_dpath: PathBuf,
+    genned_queries_dpath: PathBuf,
+    pub schema_fpath: PathBuf,
+    pub constraints_fpath: PathBuf,
+    pub indexes_fpath: PathBuf,
+}
+
+impl TpchKit {
+    pub fn build<P: AsRef<Path>>(workspace_dpath: P) -> io::Result<Self> {
+        log::debug!("[start] building TpchKit");
+
+        // build paths, sometimes creating them if they don't exist
+        let workspace_dpath = workspace_dpath.as_ref().to_path_buf();
+        let tpch_dpath = workspace_dpath.join("tpch");
+        if !tpch_dpath.exists() {
+            fs::create_dir(&tpch_dpath)?;
+        }
+        let tpch_kit_repo_dpath = tpch_dpath.join("tpch-kit");
+        let dbgen_dpath = tpch_kit_repo_dpath.join("dbgen");
+        let queries_dpath = dbgen_dpath.join("queries");
+        let genned_tables_dpath = tpch_dpath.join("genned_tables");
+        if !genned_tables_dpath.exists() {
+            fs::create_dir(&genned_tables_dpath)?;
+        }
+        let genned_queries_dpath = tpch_dpath.join("genned_queries");
+        if !genned_queries_dpath.exists() {
+            fs::create_dir(&genned_queries_dpath)?;
+        }
+        let schema_fpath = dbgen_dpath.join("dss.ddl");
+        let constraints_fpath = dbgen_dpath.join("constraints.sql");
+        let indexes_fpath = dbgen_dpath.join("indexes.sql");
+
+        // create Self
+        let kit = TpchKit {
+            _workspace_dpath: workspace_dpath,
+            _tpch_dpath: tpch_dpath,
+            tpch_kit_repo_dpath,
+            queries_dpath,
+            dbgen_dpath,
+            genned_tables_dpath,
+            genned_queries_dpath,
+            schema_fpath,
+            constraints_fpath,
+            indexes_fpath,
+        };
+
+        // setup
+        env::set_var("DSS_CONFIG", kit.dbgen_dpath.to_str().unwrap());
+        env::set_var("DSS_QUERY", kit.queries_dpath.to_str().unwrap());
+        shell::clonepull_repo(TPCH_KIT_REPO_URL, &kit.tpch_kit_repo_dpath)?;
+
+        log::debug!("[end] building TpchKit");
+        Ok(kit)
+    }
+
+    pub fn make(&self, dbms: &str) -> io::Result<()> {
+        log::debug!("[start] building dbgen");
+        // we need to call "make clean" because we might have called make earlier with
+        //   a different dbms
+        shell::run_command_with_status_check_in_dir("make clean", &self.dbgen_dpath)?;
+        shell::run_command_with_status_check_in_dir(
+            &format!("make MACHINE={} DATABASE={}", TpchKit::get_machine(), dbms),
+            &self.dbgen_dpath,
+        )?;
+        log::debug!("[end] building dbgen");
+        Ok(())
+    }
+
+    fn get_machine() -> &'static str {
+        match OS {
+            "linux" => "LINUX",
+            "macos" => "MACOS",
+            "windows" => "WIN32",
+            _ => unimplemented!(),
+        }
+    }
+
+    /// Generates the .tbl files for all tables of TPC-H
+    pub fn gen_tables(&self, tpch_kit_config: &TpchKitConfig) -> io::Result<()> {
+        let this_genned_tables_dpath = self.get_this_genned_tables_dpath(tpch_kit_config);
+        let done_fpath = this_genned_tables_dpath.join("dbgen_done");
+        if !done_fpath.exists() {
+            self.make(&tpch_kit_config.dbms)?;
+            shell::make_into_empty_dir(&this_genned_tables_dpath)?;
+            env::set_var("DSS_PATH", this_genned_tables_dpath.to_str().unwrap());
+            log::debug!("[start] generating tables for {}", tpch_kit_config);
+            shell::run_command_with_status_check_in_dir(
+                &format!("./dbgen -s{}", tpch_kit_config.scale_factor),
+                &self.dbgen_dpath,
+            )?;
+            File::create(done_fpath)?;
+            log::debug!("[end] generating tables for {}", tpch_kit_config);
+        } else {
+            log::debug!("[skip] generating tables for {}", tpch_kit_config);
+        }
+        Ok(())
+    }
+
+    pub async fn make_parquet_files(
+        &self,
+        tpch_kit_config: &TpchKitConfig,
+        schema_provider: Arc<dyn SchemaProvider>,
+    ) -> io::Result<()> {
+        let this_genned_tables_dpath = self.get_this_genned_tables_dpath(tpch_kit_config);
+        let done_fpath = this_genned_tables_dpath.join("make_parquet_done");
+
+        if !done_fpath.exists() {
+            log::debug!("[start] making parquet for {}", tpch_kit_config);
+            for csv_tbl_fpath in self.get_tbl_fpath_vec(tpch_kit_config, "tbl").unwrap() {
+                let tbl_name = Self::get_tbl_name_from_tbl_fpath(&csv_tbl_fpath);
+                let schema = schema_provider.table(&tbl_name).await.unwrap().schema();
+                let mut parquet_tbl_fpath = csv_tbl_fpath.clone();
+                parquet_tbl_fpath.set_extension("parquet");
+                let mut opts = Opts::new(csv_tbl_fpath, parquet_tbl_fpath.clone());
+                opts.delimiter = '|';
+                opts.schema = Some(schema.as_ref().clone());
+                csv2parquet::convert(opts).unwrap();
+            }
+            File::create(done_fpath)?;
+            log::debug!("[end] making parquet for {}", tpch_kit_config);
+        } else {
+            log::debug!("[skip] making parquet for {}", tpch_kit_config);
+        }
+
+        Ok(())
+    }
+
+    /// Generates the .sql files for all queries of TPC-H, with one .sql file per query
+    pub fn gen_queries(&self, tpch_kit_config: &TpchKitConfig) -> io::Result<()> {
+        let this_genned_queries_dpath = self.get_this_genned_queries_dpath(tpch_kit_config);
+        let done_fpath = this_genned_queries_dpath.join("qgen_done");
+        if !done_fpath.exists() {
+            self.make(&tpch_kit_config.dbms)?;
+            shell::make_into_empty_dir(&this_genned_queries_dpath)?;
+            log::debug!("[start] generating queries for {}", tpch_kit_config);
+            // we don't use -d in qgen because -r controls the substitution values we use
+            for query_i in 1..=NUM_TPCH_QUERIES {
+                let output = shell::run_command_with_status_check_in_dir(
+                    &format!(
+                        "./qgen -s{} -r{} {}",
+                        tpch_kit_config.scale_factor, tpch_kit_config.seed, query_i
+                    ),
+                    &self.dbgen_dpath,
+                )?;
+                let this_genned_queries_fpath =
+                    this_genned_queries_dpath.join(format!("{}.sql", query_i));
+                fs::write(&this_genned_queries_fpath, output.stdout)?;
+            }
+            File::create(done_fpath)?;
+            log::debug!("[end] generating queries for {}", tpch_kit_config);
+        } else {
+            log::debug!("[skip] generating queries for {}", tpch_kit_config);
+        }
+        Ok(())
+    }
+
+    /// If two TpchKitConfig instances would always generate the same data, then their directory
+    ///   names must be the same.
+    /// If two TpchKitConfig instances would *not always* generate the same data, then their
+    ///   directory names must be different.
+    fn get_this_genned_tables_dpath(&self, tpch_kit_config: &TpchKitConfig) -> PathBuf {
+        let dname = format!(
+            "db{}_sf{}",
+            tpch_kit_config.dbms, tpch_kit_config.scale_factor,
+        );
+        self.genned_tables_dpath.join(dname)
+    }
+
+    /// Same comment as for get_this_genned_tables_dpath, but replace "data" with "queries"
+    fn get_this_genned_queries_dpath(&self, tpch_kit_config: &TpchKitConfig) -> PathBuf {
+        let dname = format!(
+            "db{}_sf{}_sd{}",
+            tpch_kit_config.dbms, tpch_kit_config.scale_factor, tpch_kit_config.seed
+        );
+        self.genned_queries_dpath.join(dname)
+    }
+
+    /// Convert a tbl_fpath into the table name
+    pub fn get_tbl_name_from_tbl_fpath<P: AsRef<Path>>(tbl_fpath: P) -> String {
+        tbl_fpath
+            .as_ref()
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    /// Get a vector of all generated .tbl files of a given config
+    pub fn get_tbl_fpath_vec(
+        &self,
+        tpch_kit_config: &TpchKitConfig,
+        target_ext: &str,
+    ) -> io::Result<Vec<PathBuf>> {
+        let this_genned_tables_dpath = self.get_this_genned_tables_dpath(tpch_kit_config);
+        let dirent_iter = fs::read_dir(this_genned_tables_dpath)?;
+
+        let tbl_fpath_vec: Vec<PathBuf> = dirent_iter
+            .filter_map(|dirent| dirent.ok())
+            .map(|dirent| dirent.path())
+            .filter(|path| {
+                path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext == target_ext)
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        Ok(tbl_fpath_vec)
+    }
+
+    /// Get an iterator through all generated .sql files _in order_ of a given config
+    /// It's important to iterate _in order_ due to the interface of CardbenchRunnerDBMSHelper
+    pub fn get_sql_fpath_ordered_iter(
+        &self,
+        tpch_kit_config: &TpchKitConfig,
+    ) -> io::Result<impl Iterator<Item = (String, PathBuf)>> {
+        let this_genned_queries_dpath = self.get_this_genned_queries_dpath(tpch_kit_config);
+        let sql_fpath_ordered_iter =
+            tpch_kit_config
+                .query_ids
+                .clone()
+                .into_iter()
+                .map(move |query_id| {
+                    let this_genned_query_fpath =
+                        this_genned_queries_dpath.join(format!("{}.sql", &query_id));
+                    (query_id, this_genned_query_fpath)
+                });
+        Ok(sql_fpath_ordered_iter)
+    }
+}

--- a/optd-cost-model-perf/src/tpch/mod.rs
+++ b/optd-cost-model-perf/src/tpch/mod.rs
@@ -1,7 +1,4 @@
-// Copyright (c) 2023-2024 CMU Database Group
-//
-// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
+pub mod q6;
 
 use std::env::consts::OS;
 use std::fmt::{self, Display, Formatter};
@@ -13,6 +10,8 @@ use std::{env, fs, io};
 /// A wrapper around tpch-kit
 use csv2parquet::Opts;
 use datafusion::catalog::schema::SchemaProvider;
+use optd_cost_model::common::nodes::{ArcPredicateNode, PhysicalNodeType};
+use optd_cost_model::{ComputeCostContext, EstimatedStatistic};
 use serde::{Deserialize, Serialize};
 
 use crate::shell;
@@ -21,6 +20,36 @@ const TPCH_KIT_REPO_URL: &str = "https://github.com/wangpatrick57/tpch-kit.git";
 pub const TPCH_KIT_POSTGRES: &str = "POSTGRESQL";
 const NUM_TPCH_QUERIES: usize = 22;
 pub const WORKING_QUERY_IDS: &[&str] = &["6"];
+
+/// TPC-H
+///
+/// | Table Name | ID |
+/// |------------|----|
+/// | part       | 0  |
+/// | region     | 1  |
+/// | supplier   | 2  |
+/// | orders     | 3  |
+/// | nation     | 4  |
+/// | lineitem   | 5  |
+/// | partsupp   | 6  |
+/// | customer   | 7  |
+///
+pub const PART_TABLE_ID: u64 = 0;
+pub const REGION_TABLE_ID: u64 = 1;
+pub const SUPPLIER_TABLE_ID: u64 = 2;
+pub const ORDERS_TABLE_ID: u64 = 3;
+pub const NATION_TABLE_ID: u64 = 4;
+pub const LINEITEM_TABLE_ID: u64 = 5;
+pub const PARTSUPP_TABLE_ID: u64 = 6;
+pub const CUSTOMER_TABLE_ID: u64 = 7;
+
+#[derive(Debug, Clone)]
+pub struct OperatorNode {
+    pub typ: PhysicalNodeType,
+    pub predicates: Vec<ArcPredicateNode>,
+    pub children_stats: Vec<EstimatedStatistic>,
+    pub context: ComputeCostContext,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TpchKitConfig {

--- a/optd-cost-model-perf/src/tpch/mod.rs
+++ b/optd-cost-model-perf/src/tpch/mod.rs
@@ -317,3 +317,20 @@ impl TpchKit {
         Ok(sql_fpath_ordered_iter)
     }
 }
+
+#[macro_export]
+macro_rules! init_tpch_query {
+    ($query_id:ident) => {
+        paste::paste! {
+            pub fn [<init_tpch_ $query_id>]() -> (
+                HashMap<GroupId, MemoGroupInfo>,
+                Vec<OperatorNode>,
+            ) {
+                (
+                    [<create_tpch_ $query_id _memo>](),
+                    [<create_tpch_ $query_id _nodes>](),
+                )
+            }
+        }
+    };
+}

--- a/optd-cost-model-perf/src/tpch/mod.rs
+++ b/optd-cost-model-perf/src/tpch/mod.rs
@@ -1,4 +1,7 @@
+pub mod q2;
 pub mod q6;
+pub mod q8;
+pub mod q9;
 
 use std::env::consts::OS;
 use std::fmt::{self, Display, Formatter};

--- a/optd-cost-model-perf/src/tpch/mod.rs
+++ b/optd-cost-model-perf/src/tpch/mod.rs
@@ -1,5 +1,6 @@
 pub mod q2;
 pub mod q6;
+pub mod q7;
 pub mod q8;
 pub mod q9;
 

--- a/optd-cost-model-perf/src/tpch/q2.rs
+++ b/optd-cost-model-perf/src/tpch/q2.rs
@@ -1,0 +1,848 @@
+use std::sync::Arc;
+
+use datafusion_expr::AggregateFunction;
+use optd_cost_model::{
+    common::{
+        nodes::{JoinType, PhysicalNodeType, PredicateNode, PredicateType},
+        predicates::{
+            bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
+            log_op_pred::LogOpType, sort_order_pred::SortOrderType,
+        },
+        types::{ExprId, GroupId},
+        values::Value,
+    },
+    ComputeCostContext,
+};
+
+use crate::tpch::{
+    NATION_TABLE_ID, PARTSUPP_TABLE_ID, PART_TABLE_ID, REGION_TABLE_ID, SUPPLIER_TABLE_ID,
+};
+
+use super::OperatorNode;
+
+pub fn create_tpch_q2_nodes() -> Vec<OperatorNode> {
+    let node_114 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalLimit,
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::Constant(ConstantType::UInt64),
+                children: vec![],
+                data: Some(Value::UInt64(0)),
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::Constant(ConstantType::UInt64),
+                children: vec![],
+                data: Some(Value::UInt64(100)),
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(114),
+            expr_id: ExprId(117),
+            children_group_ids: vec![GroupId(110)],
+        },
+    };
+
+    let node_110 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalSort,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Desc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(2)),
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(3)),
+                    })],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(110),
+            expr_id: ExprId(12508),
+            children_group_ids: vec![GroupId(107)],
+        },
+    };
+
+    let node_107 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(19)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(15)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(22)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(16)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(18)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(20)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(107),
+            expr_id: ExprId(16293),
+            children_group_ids: vec![GroupId(12190)],
+        },
+    };
+
+    let node_12190 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(12)),
+                    }),
+                ],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    }),
+                ],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(12190),
+            expr_id: ExprId(16296),
+            children_group_ids: vec![GroupId(11835), GroupId(101)],
+        },
+    };
+
+    let node_101 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(101),
+            expr_id: ExprId(12515),
+            children_group_ids: vec![GroupId(98)],
+        },
+    };
+
+    let node_98 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalAgg,
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Agg(AggregateFunction::Min)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(1)),
+                        })],
+                        data: None,
+                    })],
+                    data: None,
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(98),
+            expr_id: ExprId(12518),
+            children_group_ids: vec![GroupId(94)],
+        },
+    };
+
+    let node_94 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(94),
+            expr_id: ExprId(12520),
+            children_group_ids: vec![GroupId(91)],
+        },
+    };
+
+    let node_91 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(91),
+            expr_id: ExprId(12523),
+            children_group_ids: vec![GroupId(84), GroupId(56)],
+        },
+    };
+
+    let node_84 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(84),
+            expr_id: ExprId(12525),
+            children_group_ids: vec![GroupId(81)],
+        },
+    };
+
+    let node_81 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(81),
+            expr_id: ExprId(12528),
+            children_group_ids: vec![GroupId(74), GroupId(78)],
+        },
+    };
+
+    let node_78 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(78),
+            expr_id: ExprId(12545),
+            children_group_ids: vec![GroupId(35)],
+        },
+    };
+
+    let node_74 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(74),
+            expr_id: ExprId(12530),
+            children_group_ids: vec![GroupId(71)],
+        },
+    };
+
+    let node_71 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(71),
+            expr_id: ExprId(12533),
+            children_group_ids: vec![GroupId(17), GroupId(68)],
+        },
+    };
+
+    let node_68 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(68),
+            expr_id: ExprId(12539),
+            children_group_ids: vec![GroupId(26)],
+        },
+    };
+
+    let node_17 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(17),
+            expr_id: ExprId(12535),
+            children_group_ids: vec![GroupId(14)],
+        },
+    };
+
+    let node_11835 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(23)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11835),
+            expr_id: ExprId(15837),
+            children_group_ids: vec![GroupId(11494), GroupId(56)],
+        },
+    };
+
+    let node_56 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![Arc::new(PredicateNode {
+                typ: PredicateType::AttrIndex,
+                children: vec![],
+                data: Some(Value::UInt64(0)),
+            })],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(56),
+            expr_id: ExprId(12551),
+            children_group_ids: vec![GroupId(120)],
+        },
+    };
+
+    let node_120 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::BinOp(BinOpType::Eq),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Constant(ConstantType::Utf8String),
+                    children: vec![],
+                    data: Some(Value::String("EUROPE".into())),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(120),
+            expr_id: ExprId(12553),
+            children_group_ids: vec![GroupId(47)],
+        },
+    };
+
+    let node_47 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(REGION_TABLE_ID)), // region,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(47),
+            expr_id: ExprId(12555),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_11494 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(17)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11494),
+            expr_id: ExprId(15396),
+            children_group_ids: vec![GroupId(1204), GroupId(38)],
+        },
+    };
+
+    let node_38 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(38),
+            expr_id: ExprId(12581),
+            children_group_ids: vec![GroupId(35)],
+        },
+    };
+
+    let node_35 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(NATION_TABLE_ID)), // nation,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(35),
+            expr_id: ExprId(12547),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_1204 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(10)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(1204),
+            expr_id: ExprId(13159),
+            children_group_ids: vec![GroupId(245), GroupId(26)],
+        },
+    };
+
+    let node_26 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(SUPPLIER_TABLE_ID)), // supplier,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(26),
+            expr_id: ExprId(12541),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_245 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(245),
+            expr_id: ExprId(12624),
+            children_group_ids: vec![GroupId(156), GroupId(14)],
+        },
+    };
+
+    let node_14 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(PARTSUPP_TABLE_ID)), // partsupp,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(14),
+            expr_id: ExprId(12537),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_156 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::And),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Eq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(5)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Int32),
+                            children: vec![],
+                            data: Some(Value::Int32(44)),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Like,
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(4)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                            children: vec![],
+                            data: Some(Value::String("%TIN".into())),
+                        }),
+                    ],
+                    data: Some(Value::Serialized([0, 0].into())),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(156),
+            expr_id: ExprId(12617),
+            children_group_ids: vec![GroupId(2)],
+        },
+    };
+
+    let node_2 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(PART_TABLE_ID)), // part,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(2),
+            expr_id: ExprId(12619),
+            children_group_ids: vec![],
+        },
+    };
+
+    vec![
+        node_2, node_156, node_14, node_245, node_26, node_1204, node_35, node_38, node_11494,
+        node_47, node_120, node_56, node_11835, node_17, node_68, node_71, node_74, node_78,
+        node_81, node_84, node_91, node_94, node_98, node_101, node_12190, node_107, node_110,
+        node_114,
+    ]
+}

--- a/optd-cost-model-perf/src/tpch/q2.rs
+++ b/optd-cost-model-perf/src/tpch/q2.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use datafusion_expr::AggregateFunction;
 use optd_cost_model::{
@@ -8,17 +8,2805 @@ use optd_cost_model::{
             bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
             log_op_pred::LogOpType, sort_order_pred::SortOrderType,
         },
-        types::{ExprId, GroupId},
+        properties::{
+            attr_ref::{
+                AttrRef, BaseTableAttrRef, EqPredicate, GroupAttrRefs, SemanticCorrelation,
+            },
+            schema::Schema,
+            Attribute,
+        },
+        types::{ExprId, GroupId, TableId},
         values::Value,
     },
+    test_utils::tests::MemoGroupInfo,
     ComputeCostContext,
 };
 
-use crate::tpch::{
-    NATION_TABLE_ID, PARTSUPP_TABLE_ID, PART_TABLE_ID, REGION_TABLE_ID, SUPPLIER_TABLE_ID,
+use crate::{
+    init_tpch_query,
+    tpch::{NATION_TABLE_ID, PARTSUPP_TABLE_ID, PART_TABLE_ID, REGION_TABLE_ID, SUPPLIER_TABLE_ID},
 };
 
 use super::OperatorNode;
+
+pub fn create_tpch_q2_memo() -> HashMap<GroupId, MemoGroupInfo> {
+    let mut memo = HashMap::new();
+
+    memo.insert(
+        GroupId(2),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(156),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(14),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_245 = SemanticCorrelation::new();
+    let eq_predicates = vec![EqPredicate {
+        left: BaseTableAttrRef {
+            table_id: TableId(PART_TABLE_ID), // part
+            attr_idx: 0,
+        },
+        right: BaseTableAttrRef {
+            table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+            attr_idx: 0,
+        },
+    }];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_245.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(245),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                ],
+                Some(semantic_correlation_245),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(26),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_1204 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_1204.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(1204),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                Some(semantic_correlation_1204),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(35),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "n_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(38),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11494 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11494.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11494),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                Some(semantic_correlation_11494),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(47),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "r_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(120),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "r_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(56),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::UInt64,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                    table_id: TableId(REGION_TABLE_ID), // region
+                    attr_idx: 0,
+                })],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11835 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11835.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11835),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                ],
+                Some(semantic_correlation_11835),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(17),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(68),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_71 = SemanticCorrelation::new();
+    let eq_predicates = vec![EqPredicate {
+        left: BaseTableAttrRef {
+            table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+            attr_idx: 1,
+        },
+        right: BaseTableAttrRef {
+            table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+            attr_idx: 0,
+        },
+    }];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_71.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(71),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                ],
+                Some(semantic_correlation_71),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_74 = SemanticCorrelation::new();
+    let eq_predicates = vec![EqPredicate {
+        left: BaseTableAttrRef {
+            table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+            attr_idx: 1,
+        },
+        right: BaseTableAttrRef {
+            table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+            attr_idx: 0,
+        },
+    }];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_74.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(74),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                ],
+                Some(semantic_correlation_74),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(78),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_81 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_81.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(81),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                Some(semantic_correlation_81),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_84 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_84.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(84),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                Some(semantic_correlation_84),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_91 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_91.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(91),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                ],
+                Some(semantic_correlation_91),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_94 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_94.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(94),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                ],
+                Some(semantic_correlation_94),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(98),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::Derived,
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(101),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::Derived,
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_12190 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_12190.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(12190),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                ],
+                Some(semantic_correlation_12190),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_107 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_107.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(107),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                Some(semantic_correlation_107),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_110 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_110.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(110),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                Some(semantic_correlation_110),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_114 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_114.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(114),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                Some(semantic_correlation_114),
+            ),
+        },
+    );
+
+    memo
+}
 
 pub fn create_tpch_q2_nodes() -> Vec<OperatorNode> {
     let node_114 = OperatorNode {
@@ -846,3 +3634,5 @@ pub fn create_tpch_q2_nodes() -> Vec<OperatorNode> {
         node_114,
     ]
 }
+
+init_tpch_query!(q2);

--- a/optd-cost-model-perf/src/tpch/q6.rs
+++ b/optd-cost-model-perf/src/tpch/q6.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;
 
+use crate::init_tpch_query;
+
 use super::{OperatorNode, LINEITEM_TABLE_ID};
 
 fn create_tpch_q6_memo() -> HashMap<GroupId, MemoGroupInfo> {
@@ -333,15 +335,7 @@ fn create_tpch_q6_nodes() -> Vec<OperatorNode> {
     vec![scan_node, filter_node, projection_node, agg_node]
 }
 
-pub fn init_tpch_q6() -> (
-    Vec<TableId>,
-    HashMap<GroupId, MemoGroupInfo>,
-    Vec<OperatorNode>,
-) {
-    let memo = create_tpch_q6_memo();
-    let nodes = create_tpch_q6_nodes();
-    (vec![TableId(LINEITEM_TABLE_ID)], memo, nodes)
-}
+init_tpch_query!(q6);
 
 #[cfg(test)]
 pub mod tests {

--- a/optd-cost-model-perf/src/tpch/q7.rs
+++ b/optd-cost-model-perf/src/tpch/q7.rs
@@ -1,0 +1,3663 @@
+use std::{collections::HashMap, sync::Arc};
+
+use datafusion_expr::{AggregateFunction, BuiltinScalarFunction};
+use optd_cost_model::{
+    common::{
+        nodes::{JoinType, PhysicalNodeType, PredicateNode, PredicateType},
+        predicates::{
+            bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
+            log_op_pred::LogOpType, sort_order_pred::SortOrderType,
+        },
+        properties::{
+            attr_ref::{
+                AttrRef, BaseTableAttrRef, EqPredicate, GroupAttrRefs, SemanticCorrelation,
+            },
+            schema::Schema,
+            Attribute,
+        },
+        types::{ExprId, GroupId, TableId},
+        values::{SerializableOrderedF64, Value},
+    },
+    test_utils::tests::MemoGroupInfo,
+    ComputeCostContext,
+};
+use ordered_float::OrderedFloat;
+
+use crate::{
+    init_tpch_query,
+    tpch::{NATION_TABLE_ID, SUPPLIER_TABLE_ID},
+};
+
+use super::{OperatorNode, CUSTOMER_TABLE_ID, LINEITEM_TABLE_ID, ORDERS_TABLE_ID};
+
+pub fn create_tpch_q7_memo() -> HashMap<GroupId, MemoGroupInfo> {
+    let mut memo = HashMap::new();
+
+    memo.insert(
+        GroupId(2),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(8),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(96),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_118 = SemanticCorrelation::new();
+    let eq_predicates = vec![EqPredicate {
+        left: BaseTableAttrRef {
+            table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+            attr_idx: 0,
+        },
+        right: BaseTableAttrRef {
+            table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+            attr_idx: 2,
+        },
+    }];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_118.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(118),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                Some(semantic_correlation_118),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(23),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_542 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_542.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(542),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                ],
+                Some(semantic_correlation_542),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(35),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "c_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_mktsegment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 7,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(38),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11439 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11439.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11439),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                ],
+                Some(semantic_correlation_11439),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(47),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "n_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(89),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "n_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(53),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11801 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11801.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11801),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                Some(semantic_correlation_11801),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(82),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "n_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(64),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_12177 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_12177.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(12177),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                Some(semantic_correlation_12177),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_67 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_67.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(67),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                Some(semantic_correlation_67),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_70 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_70.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(70),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                ],
+                Some(semantic_correlation_70),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(74),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(77),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo
+}
+
+fn create_tpch_q7_nodes() -> Vec<OperatorNode> {
+    let node_77 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalSort,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(2)),
+                    })],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(77),
+            expr_id: ExprId(79),
+            children_group_ids: vec![GroupId(74)],
+        },
+    };
+
+    let node_74 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalAgg,
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Agg(AggregateFunction::Sum)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(3)),
+                        })],
+                        data: None,
+                    })],
+                    data: None,
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(2)),
+                    }),
+                ],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(74),
+            expr_id: ExprId(12372),
+            children_group_ids: vec![GroupId(70)],
+        },
+    };
+
+    let node_70 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(6)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Scalar(BuiltinScalarFunction::DatePart)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![
+                            Arc::new(PredicateNode {
+                                typ: PredicateType::Constant(ConstantType::Utf8String),
+                                children: vec![],
+                                data: Some(Value::String("YEAR".into())),
+                            }),
+                            Arc::new(PredicateNode {
+                                typ: PredicateType::AttrIndex,
+                                children: vec![],
+                                data: Some(Value::UInt64(2)),
+                            }),
+                        ],
+                        data: None,
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Mul),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(0)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::BinOp(BinOpType::Sub),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::Constant(ConstantType::Decimal),
+                                    children: vec![],
+                                    data: Some(Value::Float(SerializableOrderedF64(OrderedFloat(
+                                        1.0,
+                                    )))),
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::AttrIndex,
+                                    children: vec![],
+                                    data: Some(Value::UInt64(1)),
+                                }),
+                            ],
+                            data: None,
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(70),
+            expr_id: ExprId(12374),
+            children_group_ids: vec![GroupId(67)],
+        },
+    };
+
+    let node_67 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(12)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(13)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(17)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(33)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(35)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(36)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(37)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(67),
+            expr_id: ExprId(16078),
+            children_group_ids: vec![GroupId(12177)],
+        },
+    };
+
+    let node_12177 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalNestedLoopJoin(JoinType::Inner),
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::And),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Eq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(33)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(36)),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::LogOp(LogOpType::Or),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::LogOp(LogOpType::And),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::BinOp(BinOpType::Eq),
+                                    children: vec![
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::AttrIndex,
+                                            children: vec![],
+                                            data: Some(Value::UInt64(35)),
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                                            children: vec![],
+                                            data: Some(Value::String("IRAN".into())),
+                                        }),
+                                    ],
+                                    data: None,
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::BinOp(BinOpType::Eq),
+                                    children: vec![
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::AttrIndex,
+                                            children: vec![],
+                                            data: Some(Value::UInt64(37)),
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                                            children: vec![],
+                                            data: Some(Value::String("ETHIOPIA".into())),
+                                        }),
+                                    ],
+                                    data: None,
+                                }),
+                            ],
+                            data: None,
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::LogOp(LogOpType::And),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::BinOp(BinOpType::Eq),
+                                    children: vec![
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::AttrIndex,
+                                            children: vec![],
+                                            data: Some(Value::UInt64(35)),
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                                            children: vec![],
+                                            data: Some(Value::String("ETHIOPIA".into())),
+                                        }),
+                                    ],
+                                    data: None,
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::BinOp(BinOpType::Eq),
+                                    children: vec![
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::AttrIndex,
+                                            children: vec![],
+                                            data: Some(Value::UInt64(37)),
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                                            children: vec![],
+                                            data: Some(Value::String("IRAN".into())),
+                                        }),
+                                    ],
+                                    data: None,
+                                }),
+                            ],
+                            data: None,
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(12177),
+            expr_id: ExprId(16080),
+            children_group_ids: vec![GroupId(11801), GroupId(64)],
+        },
+    };
+
+    let node_64 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(64),
+            expr_id: ExprId(12380),
+            children_group_ids: vec![GroupId(82)],
+        },
+    };
+
+    let node_82 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::Or),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Eq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(1)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                            children: vec![],
+                            data: Some(Value::String("ETHIOPIA".into())),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Eq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(1)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                            children: vec![],
+                            data: Some(Value::String("IRAN".into())),
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(82),
+            expr_id: ExprId(12382),
+            children_group_ids: vec![GroupId(47)],
+        },
+    };
+
+    let node_11801 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11801),
+            expr_id: ExprId(15708),
+            children_group_ids: vec![GroupId(11439), GroupId(53)],
+        },
+    };
+
+    let node_53 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(53),
+            expr_id: ExprId(12395),
+            children_group_ids: vec![GroupId(89)],
+        },
+    };
+
+    let node_89 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::Or),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Eq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(1)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                            children: vec![],
+                            data: Some(Value::String("IRAN".into())),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Eq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(1)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Utf8String),
+                            children: vec![],
+                            data: Some(Value::String("ETHIOPIA".into())),
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(89),
+            expr_id: ExprId(12397),
+            children_group_ids: vec![GroupId(47)],
+        },
+    };
+
+    let node_47 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(NATION_TABLE_ID)), // nation,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(47),
+            expr_id: ExprId(12384),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_11439 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(24)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11439),
+            expr_id: ExprId(15240),
+            children_group_ids: vec![GroupId(542), GroupId(38)],
+        },
+    };
+
+    let node_38 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(38),
+            expr_id: ExprId(12406),
+            children_group_ids: vec![GroupId(35)],
+        },
+    };
+
+    let node_35 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(CUSTOMER_TABLE_ID)), // customer,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(35),
+            expr_id: ExprId(12408),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_542 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(7)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(542),
+            expr_id: ExprId(12720),
+            children_group_ids: vec![GroupId(118), GroupId(23)],
+        },
+    };
+
+    let node_23 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(ORDERS_TABLE_ID)), // orders,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(23),
+            expr_id: ExprId(12417),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_118 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(118),
+            expr_id: ExprId(12449),
+            children_group_ids: vec![GroupId(2), GroupId(96)],
+        },
+    };
+
+    let node_96 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::And),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Geq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(10)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Date),
+                            children: vec![],
+                            data: Some(Value::Int64(9131)),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Leq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(10)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Date),
+                            children: vec![],
+                            data: Some(Value::Int64(9861)),
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(96),
+            expr_id: ExprId(12440),
+            children_group_ids: vec![GroupId(8)],
+        },
+    };
+
+    let node_8 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(LINEITEM_TABLE_ID)), // lineitem,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(8),
+            expr_id: ExprId(12442),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_2 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(SUPPLIER_TABLE_ID)), // supplier,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(2),
+            expr_id: ExprId(12444),
+            children_group_ids: vec![],
+        },
+    };
+
+    vec![
+        node_2, node_8, node_96, node_118, node_23, node_542, node_35, node_38, node_11439,
+        node_47, node_89, node_53, node_11801, node_82, node_64, node_12177, node_67, node_70,
+        node_74, node_77,
+    ]
+}
+
+init_tpch_query!(q7);

--- a/optd-cost-model-perf/src/tpch/q8.rs
+++ b/optd-cost-model-perf/src/tpch/q8.rs
@@ -1,0 +1,839 @@
+use std::sync::Arc;
+
+use datafusion_expr::{AggregateFunction, BuiltinScalarFunction};
+use optd_cost_model::{
+    common::{
+        nodes::{JoinType, PhysicalNodeType, PredicateNode, PredicateType},
+        predicates::{
+            bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
+            log_op_pred::LogOpType, sort_order_pred::SortOrderType,
+        },
+        types::{ExprId, GroupId},
+        values::{SerializableOrderedF64, Value},
+    },
+    ComputeCostContext,
+};
+use ordered_float::OrderedFloat;
+
+use crate::tpch::{
+    CUSTOMER_TABLE_ID, LINEITEM_TABLE_ID, NATION_TABLE_ID, ORDERS_TABLE_ID, PART_TABLE_ID,
+    REGION_TABLE_ID, SUPPLIER_TABLE_ID,
+};
+
+use super::OperatorNode;
+
+pub fn create_tpch_q8_nodes() -> Vec<OperatorNode> {
+    let node_112 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalSort,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![Arc::new(PredicateNode {
+                typ: PredicateType::SortOrder(SortOrderType::Asc),
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            })],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(112),
+            expr_id: ExprId(114),
+            children_group_ids: vec![GroupId(109)],
+        },
+    };
+
+    let node_109 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Div),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(1)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(2)),
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(109),
+            expr_id: ExprId(116),
+            children_group_ids: vec![GroupId(106)],
+        },
+    };
+
+    let node_106 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalAgg,
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::Func(FuncType::Agg(AggregateFunction::Sum)),
+                        children: vec![Arc::new(PredicateNode {
+                            typ: PredicateType::List,
+                            children: vec![Arc::new(PredicateNode {
+                                typ: PredicateType::Func(FuncType::Case),
+                                children: vec![Arc::new(PredicateNode {
+                                    typ: PredicateType::List,
+                                    children: vec![
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::BinOp(BinOpType::Eq),
+                                            children: vec![
+                                                Arc::new(PredicateNode {
+                                                    typ: PredicateType::AttrIndex,
+                                                    children: vec![],
+                                                    data: Some(Value::UInt64(2)),
+                                                }),
+                                                Arc::new(PredicateNode {
+                                                    typ: PredicateType::Constant(
+                                                        ConstantType::Utf8String,
+                                                    ),
+                                                    children: vec![],
+                                                    data: Some(Value::String("ETHIOPIA".into())),
+                                                }),
+                                            ],
+                                            data: None,
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::AttrIndex,
+                                            children: vec![],
+                                            data: Some(Value::UInt64(1)),
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::Constant(ConstantType::Decimal),
+                                            children: vec![],
+                                            data: Some(Value::Float(SerializableOrderedF64(
+                                                OrderedFloat(0.0),
+                                            ))),
+                                        }),
+                                    ],
+                                    data: None,
+                                })],
+                                data: None,
+                            })],
+                            data: None,
+                        })],
+                        data: None,
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::Func(FuncType::Agg(AggregateFunction::Sum)),
+                        children: vec![Arc::new(PredicateNode {
+                            typ: PredicateType::List,
+                            children: vec![Arc::new(PredicateNode {
+                                typ: PredicateType::AttrIndex,
+                                children: vec![],
+                                data: Some(Value::UInt64(1)),
+                            })],
+                            data: None,
+                        })],
+                        data: None,
+                    }),
+                ],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(106),
+            expr_id: ExprId(13163),
+            children_group_ids: vec![GroupId(102)],
+        },
+    };
+
+    let node_102 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Scalar(BuiltinScalarFunction::DatePart)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![
+                            Arc::new(PredicateNode {
+                                typ: PredicateType::Constant(ConstantType::Utf8String),
+                                children: vec![],
+                                data: Some(Value::String("YEAR".into())),
+                            }),
+                            Arc::new(PredicateNode {
+                                typ: PredicateType::AttrIndex,
+                                children: vec![],
+                                data: Some(Value::UInt64(2)),
+                            }),
+                        ],
+                        data: None,
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Mul),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(0)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::BinOp(BinOpType::Sub),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::Constant(ConstantType::Decimal),
+                                    children: vec![],
+                                    data: Some(Value::Float(SerializableOrderedF64(OrderedFloat(
+                                        1.0,
+                                    )))),
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::AttrIndex,
+                                    children: vec![],
+                                    data: Some(Value::UInt64(1)),
+                                }),
+                            ],
+                            data: None,
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(102),
+            expr_id: ExprId(13165),
+            children_group_ids: vec![GroupId(99)],
+        },
+    };
+
+    let node_99 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(21)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(22)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(34)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(38)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(40)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(41)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(99),
+            expr_id: ExprId(18316),
+            children_group_ids: vec![GroupId(12953)],
+        },
+    };
+
+    let node_12953 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(38)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(12953),
+            expr_id: ExprId(18319),
+            children_group_ids: vec![GroupId(12507), GroupId(96)],
+        },
+    };
+
+    let node_96 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![Arc::new(PredicateNode {
+                typ: PredicateType::AttrIndex,
+                children: vec![],
+                data: Some(Value::UInt64(0)),
+            })],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(96),
+            expr_id: ExprId(13172),
+            children_group_ids: vec![GroupId(119)],
+        },
+    };
+
+    let node_119 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::BinOp(BinOpType::Eq),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Constant(ConstantType::Utf8String),
+                    children: vec![],
+                    data: Some(Value::String("AFRICA".into())),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(119),
+            expr_id: ExprId(13174),
+            children_group_ids: vec![GroupId(87)],
+        },
+    };
+
+    let node_87 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(REGION_TABLE_ID)), // region,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(87),
+            expr_id: ExprId(13176),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_12507 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(12507),
+            expr_id: ExprId(17743),
+            children_group_ids: vec![GroupId(12075), GroupId(78)],
+        },
+    };
+
+    let node_78 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(78),
+            expr_id: ExprId(13195),
+            children_group_ids: vec![GroupId(65)],
+        },
+    };
+
+    let node_12075 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(36)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(12075),
+            expr_id: ExprId(17185),
+            children_group_ids: vec![GroupId(11657), GroupId(68)],
+        },
+    };
+
+    let node_68 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(2)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(68),
+            expr_id: ExprId(13204),
+            children_group_ids: vec![GroupId(65)],
+        },
+    };
+
+    let node_65 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(NATION_TABLE_ID)), // nation,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(65),
+            expr_id: ExprId(13197),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_11657 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(33)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11657),
+            expr_id: ExprId(16645),
+            children_group_ids: vec![GroupId(11253), GroupId(56)],
+        },
+    };
+
+    let node_56 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(56),
+            expr_id: ExprId(13211),
+            children_group_ids: vec![GroupId(53)],
+        },
+    };
+
+    let node_53 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(CUSTOMER_TABLE_ID)), // customer,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(53),
+            expr_id: ExprId(13213),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_11253 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(16)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11253),
+            expr_id: ExprId(16123),
+            children_group_ids: vec![GroupId(1004), GroupId(44)],
+        },
+    };
+
+    let node_44 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(44),
+            expr_id: ExprId(13220),
+            children_group_ids: vec![GroupId(155)],
+        },
+    };
+
+    let node_155 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::And),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Geq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(4)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Date),
+                            children: vec![],
+                            data: Some(Value::Int64(9131)),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Leq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(4)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Date),
+                            children: vec![],
+                            data: Some(Value::Int64(9861)),
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(155),
+            expr_id: ExprId(13222),
+            children_group_ids: vec![GroupId(38)],
+        },
+    };
+
+    let node_38 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(ORDERS_TABLE_ID)), // orders,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(38),
+            expr_id: ExprId(13224),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_1004 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(11)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(1004),
+            expr_id: ExprId(13696),
+            children_group_ids: vec![GroupId(26), GroupId(218)],
+        },
+    };
+
+    let node_218 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(218),
+            expr_id: ExprId(13273),
+            children_group_ids: vec![GroupId(162), GroupId(14)],
+        },
+    };
+
+    let node_14 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(LINEITEM_TABLE_ID)), // lineitem,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(14),
+            expr_id: ExprId(13264),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_162 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::BinOp(BinOpType::Eq),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Constant(ConstantType::Utf8String),
+                    children: vec![],
+                    data: Some(Value::String("SMALL BRUSHED NICKEL".into())),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(162),
+            expr_id: ExprId(13266),
+            children_group_ids: vec![GroupId(2)],
+        },
+    };
+
+    let node_2 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(PART_TABLE_ID)), // part,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(2),
+            expr_id: ExprId(13268),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_26 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(SUPPLIER_TABLE_ID)), // supplier,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(26),
+            expr_id: ExprId(13237),
+            children_group_ids: vec![],
+        },
+    };
+
+    vec![
+        node_26, node_2, node_162, node_14, node_218, node_1004, node_38, node_155, node_44,
+        node_11253, node_53, node_56, node_11657, node_65, node_68, node_12075, node_78,
+        node_12507, node_87, node_119, node_96, node_12953, node_99, node_102, node_106, node_109,
+        node_112,
+    ]
+}

--- a/optd-cost-model-perf/src/tpch/q8.rs
+++ b/optd-cost-model-perf/src/tpch/q8.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use datafusion_expr::{AggregateFunction, BuiltinScalarFunction};
 use optd_cost_model::{
@@ -8,19 +8,4026 @@ use optd_cost_model::{
             bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
             log_op_pred::LogOpType, sort_order_pred::SortOrderType,
         },
-        types::{ExprId, GroupId},
+        properties::{
+            attr_ref::{
+                AttrRef, BaseTableAttrRef, EqPredicate, GroupAttrRefs, SemanticCorrelation,
+            },
+            schema::Schema,
+            Attribute,
+        },
+        types::{ExprId, GroupId, TableId},
         values::{SerializableOrderedF64, Value},
     },
+    test_utils::tests::MemoGroupInfo,
     ComputeCostContext,
 };
 use ordered_float::OrderedFloat;
 
-use crate::tpch::{
-    CUSTOMER_TABLE_ID, LINEITEM_TABLE_ID, NATION_TABLE_ID, ORDERS_TABLE_ID, PART_TABLE_ID,
-    REGION_TABLE_ID, SUPPLIER_TABLE_ID,
+use crate::{
+    init_tpch_query,
+    tpch::{
+        CUSTOMER_TABLE_ID, LINEITEM_TABLE_ID, NATION_TABLE_ID, ORDERS_TABLE_ID, PART_TABLE_ID,
+        REGION_TABLE_ID, SUPPLIER_TABLE_ID,
+    },
 };
 
 use super::OperatorNode;
+
+pub fn create_tpch_q8_memo() -> HashMap<GroupId, MemoGroupInfo> {
+    let mut memo = HashMap::new();
+
+    memo.insert(
+        GroupId(26),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(2),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(162),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(14),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_218 = SemanticCorrelation::new();
+    let eq_predicates = vec![EqPredicate {
+        left: BaseTableAttrRef {
+            table_id: TableId(PART_TABLE_ID), // part
+            attr_idx: 0,
+        },
+        right: BaseTableAttrRef {
+            table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+            attr_idx: 1,
+        },
+    }];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_218.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(218),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                Some(semantic_correlation_218),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_1004 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_1004.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(1004),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                Some(semantic_correlation_1004),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(38),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(155),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(44),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11253 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11253.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11253),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                ],
+                Some(semantic_correlation_11253),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(53),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "c_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_mktsegment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "c_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 7,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(56),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11657 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11657.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11657),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                ],
+                Some(semantic_correlation_11657),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(65),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "n_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(68),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_12075 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_12075.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(12075),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                ],
+                Some(semantic_correlation_12075),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(78),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_12507 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_12507.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(12507),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                Some(semantic_correlation_12507),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(87),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "r_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(119),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "r_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "r_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 2,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(96),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::UInt64,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                    table_id: TableId(REGION_TABLE_ID), // region
+                    attr_idx: 0,
+                })],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_12953 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_12953.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(12953),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                ],
+                Some(semantic_correlation_12953),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_99 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_99.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(99),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(REGION_TABLE_ID), // region
+                        attr_idx: 0,
+                    }),
+                ],
+                Some(semantic_correlation_99),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_102 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(CUSTOMER_TABLE_ID), // customer
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(REGION_TABLE_ID), // region
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_102.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(102),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::UInt64,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                Some(semantic_correlation_102),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(106),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![AttrRef::Derived, AttrRef::Derived, AttrRef::Derived],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(109),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::UInt64,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(vec![AttrRef::Derived, AttrRef::Derived], None),
+        },
+    );
+
+    memo.insert(
+        GroupId(112),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::UInt64,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(vec![AttrRef::Derived, AttrRef::Derived], None),
+        },
+    );
+
+    memo
+}
 
 pub fn create_tpch_q8_nodes() -> Vec<OperatorNode> {
     let node_112 = OperatorNode {
@@ -837,3 +4844,5 @@ pub fn create_tpch_q8_nodes() -> Vec<OperatorNode> {
         node_112,
     ]
 }
+
+init_tpch_query!(q8);

--- a/optd-cost-model-perf/src/tpch/q9.rs
+++ b/optd-cost-model-perf/src/tpch/q9.rs
@@ -1,0 +1,610 @@
+use std::sync::Arc;
+
+use datafusion_expr::{AggregateFunction, BuiltinScalarFunction};
+use optd_cost_model::{
+    common::{
+        nodes::{JoinType, PhysicalNodeType, PredicateNode, PredicateType},
+        predicates::{
+            bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
+            sort_order_pred::SortOrderType,
+        },
+        types::{ExprId, GroupId},
+        values::{SerializableOrderedF64, Value},
+    },
+    ComputeCostContext,
+};
+use ordered_float::OrderedFloat;
+
+use super::OperatorNode;
+use crate::tpch::{
+    LINEITEM_TABLE_ID, NATION_TABLE_ID, ORDERS_TABLE_ID, PARTSUPP_TABLE_ID, PART_TABLE_ID,
+    SUPPLIER_TABLE_ID,
+};
+
+pub fn create_tpch_q9_nodes() -> Vec<OperatorNode> {
+    let node_78 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalSort,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Asc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::SortOrder(SortOrderType::Desc),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    })],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(78),
+            expr_id: ExprId(80),
+            children_group_ids: vec![GroupId(75)],
+        },
+    };
+
+    let node_75 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalAgg,
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Agg(AggregateFunction::Sum)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(2)),
+                        })],
+                        data: None,
+                    })],
+                    data: None,
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    }),
+                ],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(75),
+            expr_id: ExprId(12398),
+            children_group_ids: vec![GroupId(71)],
+        },
+    };
+
+    let node_71 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(7)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Scalar(BuiltinScalarFunction::DatePart)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![
+                            Arc::new(PredicateNode {
+                                typ: PredicateType::Constant(ConstantType::Utf8String),
+                                children: vec![],
+                                data: Some(Value::String("YEAR".into())),
+                            }),
+                            Arc::new(PredicateNode {
+                                typ: PredicateType::AttrIndex,
+                                children: vec![],
+                                data: Some(Value::UInt64(5)),
+                            }),
+                        ],
+                        data: None,
+                    })],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Sub),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::BinOp(BinOpType::Mul),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::AttrIndex,
+                                    children: vec![],
+                                    data: Some(Value::UInt64(1)),
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::BinOp(BinOpType::Sub),
+                                    children: vec![
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::Constant(ConstantType::Decimal),
+                                            children: vec![],
+                                            data: Some(Value::Float(SerializableOrderedF64(
+                                                OrderedFloat(1.0),
+                                            ))),
+                                        }),
+                                        Arc::new(PredicateNode {
+                                            typ: PredicateType::AttrIndex,
+                                            children: vec![],
+                                            data: Some(Value::UInt64(2)),
+                                        }),
+                                    ],
+                                    data: None,
+                                }),
+                            ],
+                            data: None,
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::BinOp(BinOpType::Mul),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::AttrIndex,
+                                    children: vec![],
+                                    data: Some(Value::UInt64(4)),
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::AttrIndex,
+                                    children: vec![],
+                                    data: Some(Value::UInt64(0)),
+                                }),
+                            ],
+                            data: None,
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(71),
+            expr_id: ExprId(12400),
+            children_group_ids: vec![GroupId(68)],
+        },
+    };
+
+    let node_68 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(68),
+            expr_id: ExprId(16554),
+            children_group_ids: vec![GroupId(59), GroupId(65)],
+        },
+    };
+
+    let node_65 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(65),
+            expr_id: ExprId(12407),
+            children_group_ids: vec![GroupId(62)],
+        },
+    };
+
+    let node_62 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(NATION_TABLE_ID)), // nation,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(62),
+            expr_id: ExprId(12409),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_59 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(13)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(14)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(15)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(28)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(34)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(36)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(59),
+            expr_id: ExprId(15866),
+            children_group_ids: vec![GroupId(11775)],
+        },
+    };
+
+    let node_11775 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(9)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11775),
+            expr_id: ExprId(15869),
+            children_group_ids: vec![GroupId(11371), GroupId(53)],
+        },
+    };
+
+    let node_53 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(4)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(53),
+            expr_id: ExprId(12416),
+            children_group_ids: vec![GroupId(50)],
+        },
+    };
+
+    let node_50 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(ORDERS_TABLE_ID)), // orders,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(50),
+            expr_id: ExprId(12418),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_11371 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(11)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(10)),
+                    }),
+                ],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(1)),
+                    }),
+                    Arc::new(PredicateNode {
+                        typ: PredicateType::AttrIndex,
+                        children: vec![],
+                        data: Some(Value::UInt64(0)),
+                    }),
+                ],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11371),
+            expr_id: ExprId(15347),
+            children_group_ids: vec![GroupId(893), GroupId(41)],
+        },
+    };
+
+    let node_41 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(3)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(41),
+            expr_id: ExprId(12425),
+            children_group_ids: vec![GroupId(38)],
+        },
+    };
+
+    let node_38 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(PARTSUPP_TABLE_ID)), // partsupp,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(38),
+            expr_id: ExprId(12427),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_893 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(11)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(893),
+            expr_id: ExprId(12922),
+            children_group_ids: vec![GroupId(139), GroupId(26)],
+        },
+    };
+
+    let node_26 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(SUPPLIER_TABLE_ID)), // supplier,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(26),
+            expr_id: ExprId(12436),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_139 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalHashJoin(JoinType::Inner),
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(0)),
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                })],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(139),
+            expr_id: ExprId(12472),
+            children_group_ids: vec![GroupId(83), GroupId(14)],
+        },
+    };
+
+    let node_14 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(LINEITEM_TABLE_ID)), // lineitem,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(14),
+            expr_id: ExprId(12463),
+            children_group_ids: vec![],
+        },
+    };
+
+    let node_83 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Like,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(1)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::Constant(ConstantType::Utf8String),
+                    children: vec![],
+                    data: Some(Value::String("%forest%".into())),
+                }),
+            ],
+            data: Some(Value::Serialized([0, 0].into())),
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(83),
+            expr_id: ExprId(12465),
+            children_group_ids: vec![GroupId(2)],
+        },
+    };
+
+    let node_2 = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(PART_TABLE_ID)), // part,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(2),
+            expr_id: ExprId(12467),
+            children_group_ids: vec![],
+        },
+    };
+
+    vec![
+        node_2, node_83, node_14, node_139, node_26, node_893, node_38, node_41, node_11371,
+        node_50, node_53, node_11775, node_59, node_62, node_65, node_68, node_71, node_75,
+        node_78,
+    ]
+}

--- a/optd-cost-model-perf/src/tpch/q9.rs
+++ b/optd-cost-model-perf/src/tpch/q9.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use datafusion_expr::{AggregateFunction, BuiltinScalarFunction};
 use optd_cost_model::{
@@ -8,18 +8,2582 @@ use optd_cost_model::{
             bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
             sort_order_pred::SortOrderType,
         },
-        types::{ExprId, GroupId},
+        properties::{
+            attr_ref::{
+                AttrRef, BaseTableAttrRef, EqPredicate, GroupAttrRefs, SemanticCorrelation,
+            },
+            schema::Schema,
+            Attribute,
+        },
+        types::{ExprId, GroupId, TableId},
         values::{SerializableOrderedF64, Value},
     },
+    test_utils::tests::MemoGroupInfo,
     ComputeCostContext,
 };
 use ordered_float::OrderedFloat;
 
 use super::OperatorNode;
-use crate::tpch::{
-    LINEITEM_TABLE_ID, NATION_TABLE_ID, ORDERS_TABLE_ID, PARTSUPP_TABLE_ID, PART_TABLE_ID,
-    SUPPLIER_TABLE_ID,
+use crate::{
+    init_tpch_query,
+    tpch::{
+        LINEITEM_TABLE_ID, NATION_TABLE_ID, ORDERS_TABLE_ID, PARTSUPP_TABLE_ID, PART_TABLE_ID,
+        SUPPLIER_TABLE_ID,
+    },
 };
+
+pub fn create_tpch_q9_memo() -> HashMap<GroupId, MemoGroupInfo> {
+    let mut memo = HashMap::new();
+
+    memo.insert(
+        GroupId(2),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(83),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(14),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_139 = SemanticCorrelation::new();
+    let eq_predicates = vec![EqPredicate {
+        left: BaseTableAttrRef {
+            table_id: TableId(PART_TABLE_ID), // part
+            attr_idx: 0,
+        },
+        right: BaseTableAttrRef {
+            table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+            attr_idx: 1,
+        },
+    }];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_139.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(139),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                ],
+                Some(semantic_correlation_139),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(26),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_893 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_893.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(893),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                ],
+                Some(semantic_correlation_893),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(38),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "ps_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_availqty".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_supplycost".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "ps_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 4,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(41),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11371 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11371.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11371),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                ],
+                Some(semantic_correlation_11371),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(50),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "o_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_custkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderstatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_totalprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_orderpriority".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_clerk".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_shippriority".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "o_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 8,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(53),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_11775 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_11775.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(11775),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "p_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_mfgr".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_brand".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_type".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_size".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_container".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_retailprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "p_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_orderkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_partkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linenumber".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_quantity".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_extendedprice".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_discount".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_tax".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_returnflag".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_linestatus".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_commitdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_receiptdate".to_string(),
+                        typ: ConstantType::Date,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipinstruct".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_shipmode".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "l_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_suppkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_address".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_phone".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_acctbal".to_string(),
+                        typ: ConstantType::Decimal,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "s_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PART_TABLE_ID), // part
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 7,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 8,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 9,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 10,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 11,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 12,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 13,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 14,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 15,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                ],
+                Some(semantic_correlation_11775),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_59 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_59.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(59),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                ],
+                Some(semantic_correlation_59),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(62),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "n_nationkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_name".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_regionkey".to_string(),
+                        typ: ConstantType::Int32,
+                        nullable: false,
+                    },
+                    Attribute {
+                        name: "n_comment".to_string(),
+                        typ: ConstantType::Utf8String,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 2,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 3,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(65),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                None,
+            ),
+        },
+    );
+
+    let mut semantic_correlation_68 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_68.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(68),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 5,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                        attr_idx: 6,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                        attr_idx: 3,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(ORDERS_TABLE_ID), // orders
+                        attr_idx: 4,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 0,
+                    }),
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                ],
+                Some(semantic_correlation_68),
+            ),
+        },
+    );
+
+    let mut semantic_correlation_71 = SemanticCorrelation::new();
+    let eq_predicates = vec![
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(ORDERS_TABLE_ID), // orders
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(PARTSUPP_TABLE_ID), // partsupp
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(PART_TABLE_ID), // part
+                attr_idx: 0,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 1,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(LINEITEM_TABLE_ID), // lineitem
+                attr_idx: 2,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 0,
+            },
+        },
+        EqPredicate {
+            left: BaseTableAttrRef {
+                table_id: TableId(SUPPLIER_TABLE_ID), // supplier
+                attr_idx: 3,
+            },
+            right: BaseTableAttrRef {
+                table_id: TableId(NATION_TABLE_ID), // nation
+                attr_idx: 0,
+            },
+        },
+    ];
+    for eq_predicate in eq_predicates {
+        semantic_correlation_71.add_predicate(eq_predicate);
+    }
+    memo.insert(
+        GroupId(71),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::UInt64,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                ],
+                Some(semantic_correlation_71),
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(75),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo.insert(
+        GroupId(78),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::Binary,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                    Attribute {
+                        name: "unnamed".to_string(),
+                        typ: ConstantType::UInt64,
+                        nullable: true,
+                    },
+                ],
+            },
+            attr_refs: GroupAttrRefs::new(
+                vec![
+                    AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+                        table_id: TableId(NATION_TABLE_ID), // nation
+                        attr_idx: 1,
+                    }),
+                    AttrRef::Derived,
+                    AttrRef::Derived,
+                ],
+                None,
+            ),
+        },
+    );
+
+    memo
+}
 
 pub fn create_tpch_q9_nodes() -> Vec<OperatorNode> {
     let node_78 = OperatorNode {
@@ -608,3 +3172,5 @@ pub fn create_tpch_q9_nodes() -> Vec<OperatorNode> {
         node_78,
     ]
 }
+
+init_tpch_query!(q9);

--- a/optd-cost-model-perf/src/tpch_q6.rs
+++ b/optd-cost-model-perf/src/tpch_q6.rs
@@ -1,0 +1,385 @@
+use datafusion_expr::AggregateFunction;
+use optd_cost_model::common::nodes::{
+    ArcPredicateNode, PhysicalNodeType, PredicateNode, PredicateType,
+};
+use optd_cost_model::common::predicates::log_op_pred::LogOpType;
+use optd_cost_model::common::predicates::{
+    bin_op_pred::BinOpType, constant_pred::ConstantType, func_pred::FuncType,
+};
+use optd_cost_model::common::properties::attr_ref::{AttrRef, BaseTableAttrRef, GroupAttrRefs};
+use optd_cost_model::common::properties::schema::Schema;
+use optd_cost_model::common::properties::Attribute;
+use optd_cost_model::common::types::{ExprId, GroupId, TableId};
+use optd_cost_model::common::values::{SerializableOrderedF64, Value};
+use optd_cost_model::test_utils::tests::MemoGroupInfo;
+use optd_cost_model::{ComputeCostContext, EstimatedStatistic};
+use ordered_float::OrderedFloat;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::vec;
+
+const LINETIME_TABLE_ID: u64 = 5;
+
+#[derive(Debug, Clone)]
+pub struct OperatorNode {
+    pub typ: PhysicalNodeType,
+    pub predicates: Vec<ArcPredicateNode>,
+    pub children_stats: Vec<EstimatedStatistic>,
+    pub context: ComputeCostContext,
+}
+
+fn create_tpch_q6_memo() -> HashMap<GroupId, MemoGroupInfo> {
+    let mut memo = HashMap::new();
+    let mut attribute_refs = vec![];
+    for i in 0..15 {
+        attribute_refs.push(AttrRef::BaseTableAttrRef(BaseTableAttrRef {
+            table_id: TableId(LINETIME_TABLE_ID), // lineitem
+            attr_idx: i,
+        }));
+    }
+    let schema_complete = Schema {
+        attributes: vec![
+            Attribute {
+                name: "l_orderkey".to_string(),
+                typ: ConstantType::Int32,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_partkey".to_string(),
+                typ: ConstantType::Int32,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_suppkey".to_string(),
+                typ: ConstantType::Int32,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_linenumber".to_string(),
+                typ: ConstantType::Int32,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_quantity".to_string(),
+                typ: ConstantType::Decimal,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_extendedprice".to_string(),
+                typ: ConstantType::Decimal,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_discount".to_string(),
+                typ: ConstantType::Decimal,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_tax".to_string(),
+                typ: ConstantType::Decimal,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_returnflag".to_string(),
+                typ: ConstantType::Utf8String,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_linestatus".to_string(),
+                typ: ConstantType::Utf8String,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_shipdate".to_string(),
+                typ: ConstantType::Date,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_commitdate".to_string(),
+                typ: ConstantType::Date,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_receiptdate".to_string(),
+                typ: ConstantType::Date,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_shipinstruct".to_string(),
+                typ: ConstantType::Utf8String,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_shipmode".to_string(),
+                typ: ConstantType::Utf8String,
+                nullable: false,
+            },
+            Attribute {
+                name: "l_comment".to_string(),
+                typ: ConstantType::Utf8String,
+                nullable: false,
+            },
+        ],
+    };
+
+    // Agg node
+    memo.insert(
+        GroupId(15),
+        MemoGroupInfo {
+            schema: Schema {
+                attributes: vec![Attribute {
+                    name: "unnamed".to_string(),
+                    typ: ConstantType::Binary,
+                    nullable: true,
+                }],
+            },
+            attr_refs: GroupAttrRefs::new(vec![], None), // What is the AttrRef in this case??
+        },
+    );
+
+    // Filter node
+    memo.insert(
+        GroupId(18),
+        MemoGroupInfo {
+            schema: schema_complete.clone(),
+            attr_refs: GroupAttrRefs::new(attribute_refs.clone(), None),
+        },
+    );
+
+    // Scan node
+    memo.insert(
+        GroupId(2),
+        MemoGroupInfo {
+            schema: schema_complete.clone(),
+            attr_refs: GroupAttrRefs::new(attribute_refs.clone(), None),
+        },
+    );
+    memo
+}
+
+fn create_tpch_q6_nodes() -> Vec<OperatorNode> {
+    let agg_node = OperatorNode {
+        typ: PhysicalNodeType::PhysicalAgg,
+        predicates: vec![
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![Arc::new(PredicateNode {
+                    typ: PredicateType::Func(FuncType::Agg(AggregateFunction::Sum)),
+                    children: vec![Arc::new(PredicateNode {
+                        typ: PredicateType::List,
+                        children: vec![Arc::new(PredicateNode {
+                            typ: PredicateType::BinOp(BinOpType::Mul),
+                            children: vec![
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::AttrIndex,
+                                    children: vec![],
+                                    data: Some(Value::UInt64(0)),
+                                }),
+                                Arc::new(PredicateNode {
+                                    typ: PredicateType::Constant(ConstantType::Int32),
+                                    children: vec![],
+                                    data: Some(Value::UInt64(1)),
+                                }),
+                            ],
+                            data: None,
+                        })],
+                        data: None,
+                    })],
+                    data: None,
+                })],
+                data: None,
+            }),
+            Arc::new(PredicateNode {
+                typ: PredicateType::List,
+                children: vec![],
+                data: None,
+            }),
+        ],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(15),
+            expr_id: ExprId(82),
+            children_group_ids: vec![GroupId(11)],
+        },
+    };
+
+    let projection_node = OperatorNode {
+        typ: PhysicalNodeType::PhysicalProjection,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::List,
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(5)),
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::AttrIndex,
+                    children: vec![],
+                    data: Some(Value::UInt64(6)),
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(11),
+            expr_id: ExprId(84),
+            children_group_ids: vec![GroupId(18)],
+        },
+    };
+
+    let filter_node = OperatorNode {
+        typ: PhysicalNodeType::PhysicalFilter,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::LogOp(LogOpType::And),
+            children: vec![
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Geq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(10)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Date),
+                            children: vec![],
+                            data: Some(Value::Int64(9131)),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Lt),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(10)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Date),
+                            children: vec![],
+                            data: Some(Value::Int64(9496)),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Geq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(6)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Decimal),
+                            children: vec![],
+                            data: Some(Value::Float(SerializableOrderedF64(OrderedFloat(4.0)))),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Leq),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(6)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Decimal),
+                            children: vec![],
+                            data: Some(Value::Float(SerializableOrderedF64(OrderedFloat(6.0)))),
+                        }),
+                    ],
+                    data: None,
+                }),
+                Arc::new(PredicateNode {
+                    typ: PredicateType::BinOp(BinOpType::Lt),
+                    children: vec![
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::AttrIndex,
+                            children: vec![],
+                            data: Some(Value::UInt64(4)),
+                        }),
+                        Arc::new(PredicateNode {
+                            typ: PredicateType::Constant(ConstantType::Decimal),
+                            children: vec![],
+                            data: Some(Value::Float(SerializableOrderedF64(OrderedFloat(2400.0)))),
+                        }),
+                    ],
+                    data: None,
+                }),
+            ],
+            data: None,
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(18),
+            expr_id: ExprId(86),
+            children_group_ids: vec![GroupId(2)],
+        },
+    };
+
+    let scan_node = OperatorNode {
+        typ: PhysicalNodeType::PhysicalScan,
+        predicates: vec![Arc::new(PredicateNode {
+            typ: PredicateType::Constant(ConstantType::Utf8String),
+            children: vec![],
+            data: Some(Value::UInt64(LINETIME_TABLE_ID)), // lineitem
+        })],
+        children_stats: vec![],
+        context: ComputeCostContext {
+            group_id: GroupId(2),
+            expr_id: ExprId(88),
+            children_group_ids: vec![],
+        },
+    };
+    vec![scan_node, filter_node, projection_node, agg_node]
+}
+
+pub fn init_tpch_q6() -> (
+    Vec<TableId>,
+    HashMap<GroupId, MemoGroupInfo>,
+    Vec<OperatorNode>,
+) {
+    let memo = create_tpch_q6_memo();
+    let nodes = create_tpch_q6_nodes();
+    (vec![TableId(LINETIME_TABLE_ID)], memo, nodes)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::tpch_q6::create_tpch_q6_nodes;
+    use optd_cost_model::{common::types::TableId, CostModel, EstimatedStatistic};
+    use std::collections::HashMap;
+
+    use optd_cost_model::test_utils::tests::create_mock_cost_model;
+
+    #[tokio::test]
+    async fn naive_scan_test() {
+        let dummy_row_cnt = 100;
+        let cost_model = create_mock_cost_model(
+            vec![TableId(0)],
+            vec![HashMap::new()],
+            vec![Some(dummy_row_cnt)],
+        );
+        let nodes = create_tpch_q6_nodes();
+
+        let node = nodes[3].clone();
+        let res = cost_model
+            .derive_statistics(
+                node.typ,
+                &node.predicates,
+                &node.children_stats,
+                node.context,
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, EstimatedStatistic(dummy_row_cnt as f64));
+    }
+}

--- a/optd-cost-model-perf/src/tpch_q6.rs
+++ b/optd-cost-model-perf/src/tpch_q6.rs
@@ -133,7 +133,7 @@ fn create_tpch_q6_memo() -> HashMap<GroupId, MemoGroupInfo> {
                     nullable: true,
                 }],
             },
-            attr_refs: GroupAttrRefs::new(vec![], None), // What is the AttrRef in this case??
+            attr_refs: GroupAttrRefs::new(vec![AttrRef::Derived], None), // What is the AttrRef in this case??
         },
     );
 

--- a/optd-cost-model/Cargo.toml
+++ b/optd-cost-model/Cargo.toml
@@ -9,7 +9,7 @@ optd-persistent = { path = "../optd-persistent", version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.7.0", features = ["json"] }
-arrow-schema = "53.2.0"
+arrow-schema = "47.0.0"
 datafusion-expr = "32.0.0"
 datafusion = "32.0.0"
 ordered-float = "4.0"
@@ -19,8 +19,15 @@ assert_approx_eq = "1.1.0"
 trait-variant = "0.1.2"
 tokio = { version = "1.0.1", features = ["macros", "rt-multi-thread"] }
 async-trait = "0.1"
+anyhow = "1.0"
+rayon = "1.10"
+murmur2 = "0.1"
+hashbrown = "0.14.5"
 
 [dev-dependencies]
 crossbeam = "0.8"
 rand = "0.8"
 test-case = "3.3"
+
+[features]
+include-tests = []

--- a/optd-cost-model/src/stats/mod.rs
+++ b/optd-cost-model/src/stats/mod.rs
@@ -4,6 +4,7 @@ mod arith_encoder;
 pub mod utilities;
 
 use crate::common::values::Value;
+use arrow_schema::DataType;
 use serde::{Deserialize, Serialize};
 use utilities::counter::Counter;
 use utilities::{
@@ -29,6 +30,8 @@ pub const FULL_WILDCARD_SEL_FACTOR: f64 = 5.0;
 pub const FIXED_CHAR_SEL_FACTOR: f64 = 0.2;
 
 pub type AttributeCombValue = Vec<Option<Value>>;
+pub type ColumnsIdx = Vec<usize>;
+pub type ColumnsType = Vec<DataType>;
 
 // TODO: remove the clone, see the comment in the [`AttributeCombValueStats`]
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/optd-cost-model/src/stats/utilities/hyperloglog.rs
+++ b/optd-cost-model/src/stats/utilities/hyperloglog.rs
@@ -1,0 +1,303 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Implementation of the HyperLogLog data structure as described in Flajolet et al. paper:
+//! "HyperLogLog: the analysis of a near-optimal cardinality estimation algorithm" (2007).
+//! For more details, refer to:
+//! https://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
+//! We modified it by hashing objects into 64-bit values instead of 32-bit ones to reduce the
+//! number of collisions and eliminate the need for a large range correction estimator.
+
+use std::cmp::max;
+use std::marker::PhantomData;
+
+use crate::common::values::Value;
+
+use super::murmur2::murmur_hash;
+
+pub const DEFAULT_PRECISION: u8 = 16;
+
+/// Trait to transform any object into a stream of bytes.
+pub trait ByteSerializable {
+    fn to_bytes(&self) -> Vec<u8>;
+}
+
+/// The HyperLogLog (HLL) structure to provide a statistical estimate of NDistinct.
+/// For safety reasons, HLLs can only count elements of the same ByteSerializable type.
+#[derive(Clone)]
+pub struct HyperLogLog<T: ByteSerializable> {
+    registers: Vec<u8>, // The buckets to estimate HLL on (i.e. upper p bits).
+    precision: u8,      // The precision (p) of our HLL; 4 <= p <= 16.
+    m: usize,           // The number of HLL buckets; 2^p.
+    alpha: f64,         // The normal HLL multiplier factor.
+
+    data_type: PhantomData<T>, // For type checker.
+}
+
+// Serialize optd's Value.
+// TODO(Alexis): We should make stat serialization consistent.
+// This solution works for now, but a cleaner approach would be to not
+// create a new ByteSerializable interface. The initial design decision
+// was to have a way to serialize objects into bytes so we could use a custom
+// hash function and avoid hash recomputations.
+impl ByteSerializable for Vec<Option<Value>> {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for opt in self {
+            if let Some(val) = opt {
+                bytes.append(&mut val.to_string().to_bytes());
+            }
+            bytes.push(0);
+        }
+        bytes
+    }
+}
+
+// Serialize common data types for hashing (&str).
+impl ByteSerializable for &str {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}
+
+// Serialize common data types for hashing (String).
+impl ByteSerializable for String {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.as_str().to_bytes()
+    }
+}
+
+// Serialize common data types for hashing (bool).
+impl ByteSerializable for bool {
+    fn to_bytes(&self) -> Vec<u8> {
+        (*self as u8).to_bytes()
+    }
+}
+
+// Serialize common data types for hashing (numeric).
+macro_rules! impl_byte_serializable_for_numeric {
+        ($($type:ty),*) => {
+            $(
+                impl ByteSerializable for $type {
+                    fn to_bytes(&self) -> Vec<u8> {
+                        self.to_le_bytes().to_vec()
+                    }
+                }
+            )*
+        };
+    }
+
+impl_byte_serializable_for_numeric!(u128, u64, u32, u16, u8);
+impl_byte_serializable_for_numeric!(i128, i64, i32, i16, i8);
+impl_byte_serializable_for_numeric!(usize, isize);
+impl_byte_serializable_for_numeric!(f64, f32);
+
+// Self-contained implementation of the HyperLogLog data structure.
+impl<'a, T> HyperLogLog<T>
+where
+    T: ByteSerializable + 'a,
+{
+    /// Creates and initializes a new empty HyperLogLog.
+    pub fn new(precision: u8) -> Self {
+        assert!((4..=16).contains(&precision));
+
+        let m = 1 << precision;
+        let alpha = compute_alpha(m);
+
+        HyperLogLog {
+            registers: vec![0; m],
+            precision,
+            m,
+            alpha,
+
+            data_type: PhantomData,
+        }
+    }
+
+    pub fn process(&mut self, element: &T)
+    where
+        T: ByteSerializable,
+    {
+        let hash = murmur_hash(&element.to_bytes(), 0); // TODO: We ignore DoS attacks (seed).
+        let mask = (1 << (self.precision)) - 1;
+        let idx = (hash & mask) as usize; // LSB is bucket discriminator; MSB is zero streak.
+        self.registers[idx] = max(self.registers[idx], self.zeros(hash) + 1);
+    }
+
+    /// Digests an array of ByteSerializable data into the HLL.
+    pub fn aggregate<I>(&mut self, data: I)
+    where
+        I: Iterator<Item = &'a T>,
+        T: ByteSerializable,
+    {
+        data.for_each(|e| self.process(e));
+    }
+
+    /// Merges two HLLs together and returns a new one.
+    /// Particularly useful for parallel execution.
+    pub fn merge(&mut self, other: &HyperLogLog<T>) {
+        assert!(self.precision == other.precision);
+
+        self.registers = self
+            .registers
+            .iter()
+            .zip(other.registers.iter())
+            .map(|(&x, &y)| x.max(y))
+            .collect();
+    }
+
+    /// Returns an estimation of the n_distinct seen so far by the HLL.
+    pub fn n_distinct(&self) -> u64 {
+        let m = self.m as f64;
+        let raw_estimate = self.alpha * (m * m)
+            / self
+                .registers
+                .iter()
+                .fold(0.0, |acc, elem| (1.0 / 2.0f64.powi(*elem as i32)) + acc);
+
+        if raw_estimate <= ((5.0 * m) / 2.0) {
+            let empty_reg = self.registers.iter().filter(|&elem| *elem == 0).count();
+            if empty_reg != 0 {
+                (m * (m / (empty_reg as f64)).ln()).round() as u64
+            } else {
+                raw_estimate.round() as u64
+            }
+        } else {
+            raw_estimate.round() as u64
+        }
+    }
+
+    // Returns the number of consecutive zeros in hash, starting from LSB.
+    fn zeros(&self, hash: u64) -> u8 {
+        let max_bit = 64 - self.precision;
+        (0..max_bit)
+            .take_while(|i| (hash & (1 << (self.precision + i))) == 0)
+            .count() as u8
+    }
+}
+
+// Computes the alpha HLL parameter based on m.
+fn compute_alpha(m: usize) -> f64 {
+    match m {
+        16 => 0.673,
+        32 => 0.697,
+        64 => 0.709,
+        _ => 0.7213 / (1.0 + 1.079 / (m as f64)),
+    }
+}
+
+// Start of unit testing section.
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use crossbeam::thread;
+    use rand::distributions::Alphanumeric;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    use super::HyperLogLog;
+
+    #[test]
+    fn hll_small_strings() {
+        let mut hll = HyperLogLog::new(12);
+
+        let data = ["a".to_string(), "b".to_string()];
+        hll.aggregate(data.iter());
+        assert_eq!(hll.n_distinct(), data.len() as u64);
+    }
+
+    #[test]
+    fn hll_small_u64() {
+        let mut hll = HyperLogLog::new(12);
+
+        let data = [1, 2];
+        hll.aggregate(data.iter());
+        assert_eq!(hll.n_distinct(), data.len() as u64);
+    }
+
+    // Generates n random 32-char length strings that have an occurance sampled from
+    // the uniform [1:max_occ] distribution.
+    fn generate_random_strings(n: usize, max_occ: usize, job_id: usize) -> Vec<String> {
+        let mut strings = Vec::with_capacity(n);
+        for idx in 0..n {
+            let mut rng = StdRng::seed_from_u64((job_id * n + idx) as u64);
+            let rand_string: String = rng
+                .clone()
+                .sample_iter(&Alphanumeric)
+                .take(32)
+                .map(char::from)
+                .collect();
+
+            let occ: usize = rng.gen_range(1..=max_occ);
+            strings.extend(std::iter::repeat(rand_string).take(occ));
+        }
+
+        strings
+    }
+
+    // Whether obtained = expected +/- relative_error
+    fn is_close(obtained: f64, expected: f64, relative_error: f64) -> bool {
+        let margin = expected * relative_error;
+        ((expected - margin) < obtained) && (obtained < (expected + margin))
+    }
+
+    #[test]
+    fn hll_big() {
+        let precision = 12;
+        let mut hll = HyperLogLog::new(precision);
+        let n_distinct = 100000;
+        let relative_error = 0.05; // We allow a 5% relatative error rate.
+
+        let strings = generate_random_strings(n_distinct, 100, 0);
+        hll.aggregate(strings.iter());
+
+        assert!(is_close(
+            hll.n_distinct() as f64,
+            n_distinct as f64,
+            relative_error
+        ));
+    }
+
+    #[test]
+    fn hll_massive_parallel() {
+        let precision = 12;
+        let n_distinct = 100000;
+        let n_jobs = 16;
+        let relative_error = 0.05; // We allow a 5% relatative error rate.
+
+        let result_hll = Arc::new(Mutex::new(HyperLogLog::new(precision)));
+        let job_id = AtomicUsize::new(0);
+        thread::scope(|s| {
+            for _ in 0..n_jobs {
+                s.spawn(|_| {
+                    let mut local_hll = HyperLogLog::new(precision);
+                    let curr_job_id = job_id.fetch_add(1, Ordering::SeqCst);
+
+                    let strings = generate_random_strings(n_distinct, 100, curr_job_id);
+                    local_hll.aggregate(strings.iter());
+
+                    assert!(is_close(
+                        local_hll.n_distinct() as f64,
+                        n_distinct as f64,
+                        relative_error
+                    ));
+
+                    let mut result = result_hll.lock().unwrap();
+                    result.merge(&local_hll);
+                });
+            }
+        })
+        .unwrap();
+
+        let hll = result_hll.lock().unwrap();
+        assert!(is_close(
+            hll.n_distinct() as f64,
+            (n_distinct * n_jobs) as f64,
+            relative_error
+        ));
+    }
+}

--- a/optd-cost-model/src/stats/utilities/misragries.rs
+++ b/optd-cost-model/src/stats/utilities/misragries.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Implementation of the Misra-Gries Summary data structure as described in  
+//! the Cormode et al. paper: "Misra-Gries Summaries" (2014).
+//! We further refine the algorithm to ensure that K elements will always be
+//! returned, as long as K <= N.
+//! For more details, refer to:
+//! https://people.csail.mit.edu/rrw/6.045-2017/encalgs-mg.pdf
+
+use std::cmp::min;
+use std::hash::Hash;
+
+use hashbrown::HashMap;
+use itertools::Itertools;
+
+pub const DEFAULT_K_TO_TRACK: u16 = 200;
+
+/// The Misra-Gries structure to approximate the k most frequent elements in
+/// a stream of N elements. It will always identify elements with frequency
+/// f >= (n/k), and include additional leftovers.
+#[derive(Clone)]
+pub struct MisraGries<T: PartialEq + Eq + Hash + Clone> {
+    frequencies: HashMap<T, i32>, // The approximated frequencies of an element T.
+    k: u16,                       // The max size of our frequencies hashmap.
+
+    least_frequent: Option<(T, i32)>, // The least frequent element in frequencies.
+}
+
+// Self-contained implementation of the Misra-Gries data structure.
+impl<'a, T> MisraGries<T>
+where
+    T: PartialEq + Eq + Hash + Clone + 'a,
+{
+    /// Creates and initializes a new empty Misra-Gries.
+    pub fn new(k: u16) -> Self {
+        assert!(k > 0);
+
+        MisraGries::<T> {
+            frequencies: HashMap::with_capacity(k as usize),
+            k,
+
+            least_frequent: None,
+        }
+    }
+
+    // Returns the (key, val) pair of the least frequent element.
+    // If more than one such element exists, returns an arbitrary one.
+    // NOTE: Panics if no frequencies exist.
+    fn find_least_frequent(&self) -> (T, i32) {
+        let (key, occ) = self.frequencies.iter().min_by_key(|(_, occ)| *occ).unwrap();
+        (key.clone(), *occ)
+    }
+
+    // Inserts an element occ times into the `self` Misra-Gries structure.
+    pub fn insert_element(&mut self, elem: &T, occ: i32) {
+        match self.frequencies.get_mut(elem) {
+            Some(freq) => {
+                *freq += occ; // Hit.
+                if *elem == self.least_frequent.as_ref().unwrap().0 {
+                    self.least_frequent = Some(self.find_least_frequent());
+                }
+            }
+            None => {
+                if self.frequencies.len() < self.k as usize {
+                    self.frequencies.insert(elem.clone(), occ); // Discovery phase.
+
+                    match &self.least_frequent {
+                        Some(prev) => {
+                            if prev.1 > occ {
+                                self.least_frequent = Some((elem.clone(), occ));
+                            }
+                        }
+                        None => self.least_frequent = Some((elem.clone(), occ)),
+                    }
+                } else {
+                    let smallest_freq = self.least_frequent.as_ref().unwrap().1;
+
+                    let decr = min(smallest_freq, occ);
+                    if decr > 0 {
+                        for freq in self.frequencies.values_mut() {
+                            *freq -= decr;
+                        }
+                        self.least_frequent.as_mut().unwrap().1 -= decr;
+                    }
+
+                    let delta = smallest_freq - occ;
+                    if delta < 0 {
+                        self.frequencies
+                            .remove(&self.least_frequent.as_ref().unwrap().0);
+                        self.frequencies.insert(elem.clone(), -delta);
+
+                        self.least_frequent = Some(self.find_least_frequent());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Digests an array of data into the Misra-Gries structure.
+    pub fn aggregate<I>(&mut self, data: I)
+    where
+        I: Iterator<Item = &'a T>,
+    {
+        data.for_each(|key| self.insert_element(key, 1));
+    }
+
+    /// Merges another MisraGries into the current one.
+    /// Particularly useful for parallel execution.
+    pub fn merge(&mut self, other: &MisraGries<T>) {
+        assert!(self.k == other.k);
+
+        other
+            .frequencies
+            .iter()
+            .for_each(|(key, occ)| self.insert_element(key, *occ));
+    }
+
+    /// Returns all elements with frequency f >= (n/k),
+    /// and may include additional leftovers.
+    pub fn most_frequent_keys(&self) -> Vec<&T> {
+        self.frequencies.keys().collect_vec()
+    }
+}
+
+// Start of unit testing section.
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use crossbeam::thread;
+    use rand::rngs::StdRng;
+    use rand::seq::SliceRandom;
+    use rand::SeedableRng;
+
+    use super::MisraGries;
+
+    #[test]
+    fn aggregate_simple() {
+        let data = [0, 1, 2, 3];
+        let mut misra_gries = MisraGries::<i32>::new(data.len() as u16);
+
+        misra_gries.aggregate(data.iter());
+
+        for key in misra_gries.most_frequent_keys() {
+            assert!(data.contains(key));
+        }
+    }
+
+    #[test]
+    fn aggregate_double() {
+        let data = [0, 1, 2, 3];
+        let data_dup = [data.as_slice(), data.as_slice()].concat();
+
+        let mut misra_gries = MisraGries::<i32>::new(data.len() as u16);
+
+        misra_gries.aggregate(data_dup.iter());
+
+        for key in misra_gries.most_frequent_keys() {
+            assert!(data.contains(key));
+        }
+    }
+
+    // Generates a shuffled array of n distinct elements following a Zipfian
+    // distribution based on the provided seed.
+    fn create_zipfian(n_distinct: i32, seed: u64) -> Vec<i32> {
+        let mut data = Vec::<i32>::new();
+        for idx in 1..=n_distinct {
+            let occurance = n_distinct / idx;
+            for _ in 0..occurance {
+                data.push(idx);
+            }
+        }
+        let mut rng = StdRng::seed_from_u64(seed);
+        data.shuffle(&mut rng);
+
+        data
+    }
+
+    // Verifies the ability of Misra-Gries in identifying the most frequent elements
+    // in a dataset following a Zipfian distribution.
+    fn check_zipfian(misra_gries: &MisraGries<i32>, n_distinct: i32) {
+        let mfk = misra_gries.most_frequent_keys();
+        let k = misra_gries.k as i32;
+        let total_length: i32 = (1..=n_distinct).map(|idx| n_distinct / idx).sum();
+
+        assert!((1..=n_distinct)
+            .filter(|idx| (n_distinct / idx) * k >= total_length)
+            .all(|idx| mfk.contains(&&idx)));
+        assert!(mfk.len() == (k as usize));
+    }
+
+    #[test]
+    fn aggregate_zipfian() {
+        let n_distinct = 10000;
+        let k = 200;
+
+        let data = create_zipfian(n_distinct, 0);
+        let mut misra_gries = MisraGries::<i32>::new(k as u16);
+
+        misra_gries.aggregate(data.iter());
+
+        check_zipfian(&misra_gries, n_distinct);
+    }
+
+    #[test]
+    fn merge_zipfians() {
+        let n_distinct = 10000;
+        let n_jobs = 16;
+        let k = 200;
+
+        let result_misra_gries = Arc::new(Mutex::new(MisraGries::<i32>::new(k as u16)));
+        let job_id = AtomicUsize::new(0);
+        thread::scope(|s| {
+            for _ in 0..n_jobs {
+                s.spawn(|_| {
+                    let mut local_misra_gries = MisraGries::<i32>::new(k as u16);
+                    let curr_job_id = job_id.fetch_add(1, Ordering::SeqCst);
+
+                    let data = create_zipfian(n_distinct, curr_job_id as u64);
+                    local_misra_gries.aggregate(data.iter());
+
+                    check_zipfian(&local_misra_gries, n_distinct);
+
+                    let mut result = result_misra_gries.lock().unwrap();
+                    result.merge(&local_misra_gries);
+                });
+            }
+        })
+        .unwrap();
+
+        check_zipfian(&result_misra_gries.lock().unwrap(), n_distinct);
+    }
+}

--- a/optd-cost-model/src/stats/utilities/mod.rs
+++ b/optd-cost-model/src/stats/utilities/mod.rs
@@ -1,3 +1,6 @@
 pub mod counter;
+pub mod hyperloglog;
+pub mod misragries;
+pub mod murmur2;
 pub mod simple_map;
 pub mod tdigest;

--- a/optd-cost-model/src/stats/utilities/murmur2.rs
+++ b/optd-cost-model/src/stats/utilities/murmur2.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Implementation of the MurmurHash2 function, for 64b outputs, by Austin Appleby (2008).
+//! Note: Assumes little-endian machines.
+
+/// Returns the MurmurHash2 (u64) given a stream of bytes and a seed.
+pub fn murmur_hash(bytes: &[u8], seed: u64) -> u64 {
+    murmur2::murmur64a(bytes, seed)
+}
+
+// Start of unit testing section.
+#[cfg(test)]
+mod tests {
+    use super::murmur_hash;
+    #[test]
+    fn murmur_string() {
+        assert_eq!(
+            murmur_hash("Hyper🪵🪵 Rules!".as_bytes(), 1257851387),
+            1623602735526180105
+        );
+        assert_eq!(
+            murmur_hash(
+                "All work and no play makes Jack a dull boy".as_bytes(),
+                1111111111
+            ),
+            1955247671966919985
+        );
+        assert_eq!(murmur_hash("".as_bytes(), 0), 0);
+        assert_eq!(
+            murmur_hash("Gungnir™".as_bytes(), 4242424242),
+            13329505761566523763
+        );
+    }
+}

--- a/optd-cost-model/src/storage/mock.rs
+++ b/optd-cost-model/src/storage/mock.rs
@@ -1,13 +1,56 @@
-#![allow(unused_variables, dead_code)]
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
+use arrow_schema::{DataType, Schema, SchemaRef};
+use datafusion::{
+    arrow::array::{
+        Array, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array, Int32Array,
+        Int8Array, RecordBatch, StringArray, UInt16Array, UInt32Array, UInt8Array,
+    },
+    parquet::arrow::arrow_reader::ParquetRecordBatchReader,
+};
 use serde::{Deserialize, Serialize};
 
-use crate::{common::types::TableId, stats::AttributeCombValueStats, CostModelResult};
+use crate::{
+    common::values::SerializableOrderedF64,
+    stats::utilities::{
+        counter::Counter,
+        hyperloglog::{self, HyperLogLog},
+        misragries::{self, MisraGries},
+    },
+    stats::{Distribution, MostCommonValues},
+};
+use crate::{
+    common::{types::TableId, values::Value},
+    stats::{
+        utilities::tdigest::{self, TDigest},
+        AttributeCombValue, AttributeCombValueStats, ColumnsIdx, ColumnsType,
+    },
+    CostModelResult,
+};
+use itertools::Itertools;
+use ordered_float::OrderedFloat;
+use rayon::prelude::*;
 
 use super::CostModelStorageManager;
 
 pub type AttrIndices = Vec<u64>;
+
+type FirstPassState = (
+    Vec<HyperLogLog<AttributeCombValue>>,
+    Vec<MisraGries<AttributeCombValue>>,
+    Vec<i32>,
+);
+
+type SecondPassState = (
+    Vec<Option<TDigest<Value>>>,
+    Vec<Counter<AttributeCombValue>>,
+    Vec<i32>,
+);
+
+enum StatType {
+    Full,    // Mcvs, distr, n_distinct, null_frac.
+    Partial, // Only mcvs, n_distinct, null_frac.
+}
 
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, Debug)]
@@ -26,6 +69,350 @@ impl TableStats {
             row_cnt,
             column_comb_stats,
         }
+    }
+
+    fn is_type_supported(data_type: &DataType) -> bool {
+        matches!(
+            data_type,
+            DataType::Boolean
+                | DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Utf8
+        )
+    }
+
+    fn first_pass_stats_id(nb_stats: usize) -> anyhow::Result<FirstPassState> {
+        Ok((
+            vec![HyperLogLog::<AttributeCombValue>::new(hyperloglog::DEFAULT_PRECISION); nb_stats],
+            vec![MisraGries::<AttributeCombValue>::new(misragries::DEFAULT_K_TO_TRACK); nb_stats],
+            vec![0; nb_stats],
+        ))
+    }
+
+    fn second_pass_stats_id(
+        comb_stat_types: &[(Vec<usize>, Vec<DataType>, StatType)],
+        mgs: &[MisraGries<AttributeCombValue>],
+        nb_stats: usize,
+    ) -> anyhow::Result<SecondPassState> {
+        Ok((
+            comb_stat_types
+                .iter()
+                .map(|(_, _, stat_type)| match stat_type {
+                    StatType::Full => Some(TDigest::new(tdigest::DEFAULT_COMPRESSION)),
+                    StatType::Partial => None,
+                })
+                .collect(),
+            mgs.iter()
+                .map(|mg| {
+                    let mfk = mg.most_frequent_keys().into_iter().cloned().collect_vec();
+                    Counter::new(&mfk)
+                })
+                .collect(),
+            vec![0; nb_stats],
+        ))
+    }
+
+    fn get_stats_types(
+        combinations: &[ColumnsIdx],
+        schema: &SchemaRef,
+    ) -> Vec<(ColumnsIdx, ColumnsType, StatType)> {
+        let col_types: Vec<DataType> = schema
+            .fields()
+            .iter()
+            .map(|f| f.data_type().clone())
+            .collect();
+
+        combinations
+            .iter()
+            .map(|cols_idx| {
+                let cols_type: Vec<DataType> =
+                    cols_idx.iter().map(|&col| col_types[col].clone()).collect();
+                let stat_type = if cols_idx.len() == 1 {
+                    StatType::Full
+                } else {
+                    StatType::Partial
+                };
+
+                (cols_idx.clone(), cols_type, stat_type)
+            })
+            .filter(|(_, cols_type, _)| cols_type.iter().all(Self::is_type_supported))
+            .collect()
+    }
+
+    fn to_typed_column(col: &Arc<dyn Array>, col_type: &DataType) -> Vec<Option<Value>> {
+        macro_rules! simple_col_cast {
+            ({ $col:expr, $array_type:path, $value_type:path }) => {
+                $col.as_any()
+                    .downcast_ref::<$array_type>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| x.map($value_type))
+                    .collect_vec()
+            };
+        }
+
+        macro_rules! float_col_cast {
+            ({ $col:expr, $array_type:path }) => {
+                $col.as_any()
+                    .downcast_ref::<$array_type>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| {
+                        x.map(|y| {
+                            Value::Float(SerializableOrderedF64(OrderedFloat::from(y as f64)))
+                        })
+                    })
+                    .collect_vec()
+            };
+        }
+
+        macro_rules! utf8_col_cast {
+            ({ $col:expr }) => {
+                col.as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| x.map(|y| Value::String(y.to_string().into())))
+                    .collect::<Vec<_>>()
+            };
+        }
+
+        match col_type {
+            DataType::Boolean => simple_col_cast!({col, BooleanArray, Value::Bool}),
+            DataType::Int8 => simple_col_cast!({col, Int8Array, Value::Int8}),
+            DataType::Int16 => simple_col_cast!({col, Int16Array, Value::Int16}),
+            DataType::Int32 => simple_col_cast!({col, Int32Array, Value::Int32}),
+            DataType::UInt8 => simple_col_cast!({col, UInt8Array, Value::UInt8}),
+            DataType::UInt16 => simple_col_cast!({col, UInt16Array, Value::UInt16}),
+            DataType::UInt32 => simple_col_cast!({col, UInt32Array, Value::UInt32}),
+            DataType::Float32 => float_col_cast!({ col, Float32Array }),
+            DataType::Float64 => float_col_cast!({ col, Float64Array }),
+            DataType::Date32 => simple_col_cast!({col, Date32Array, Value::Date32}),
+            DataType::Utf8 => utf8_col_cast!({ col }),
+            _ => unreachable!(),
+        }
+    }
+
+    fn get_column_combs(
+        batch: &RecordBatch,
+        comb_stat_types: &[(ColumnsIdx, ColumnsType, StatType)],
+    ) -> Vec<Vec<AttributeCombValue>> {
+        comb_stat_types
+            .iter()
+            .map(|(comb, types, _)| {
+                let mut column_comb_values =
+                    vec![AttributeCombValue::with_capacity(comb.len()); batch.num_rows()];
+
+                for (&col_idx, typ) in comb.iter().zip(types.iter()) {
+                    let column_values = Self::to_typed_column(batch.column(col_idx), typ);
+
+                    for (row_values, value) in
+                        column_comb_values.iter_mut().zip(column_values.iter())
+                    {
+                        // This redundant copy is faster than making to_typed_column return an
+                        // iterator!
+                        row_values.push(value.clone());
+                    }
+                }
+
+                column_comb_values
+            })
+            .collect()
+    }
+
+    fn generate_partial_stats(
+        column_combs: &[Vec<AttributeCombValue>],
+        mgs: &mut [MisraGries<AttributeCombValue>],
+        hlls: &mut [HyperLogLog<AttributeCombValue>],
+        null_counts: &mut [i32],
+    ) {
+        column_combs
+            .iter()
+            .zip(mgs)
+            .zip(hlls)
+            .zip(null_counts)
+            .for_each(|(((column_comb, mg), hll), count)| {
+                let filtered_nulls = column_comb
+                    .iter()
+                    .filter(|row| row.iter().any(|val| val.is_some()));
+
+                *count += column_comb.len() as i32;
+
+                filtered_nulls.for_each(|e| {
+                    mg.insert_element(e, 1);
+                    hll.process(e);
+                    *count -= 1;
+                });
+            });
+    }
+
+    fn generate_full_stats(
+        column_combs: &[Vec<AttributeCombValue>],
+        cnts: &mut [Counter<AttributeCombValue>],
+        distrs: &mut [Option<TDigest<Value>>],
+        row_counts: &mut [i32],
+    ) {
+        column_combs
+            .iter()
+            .zip(cnts)
+            .zip(distrs)
+            .zip(row_counts)
+            .for_each(|(((column_comb, cnt), distr), count)| {
+                let nb_rows = column_comb.len() as i32;
+                *count += nb_rows;
+                cnt.aggregate(column_comb);
+
+                if let Some(d) = distr.as_mut() {
+                    let filtered_values: Vec<_> = column_comb
+                        .iter()
+                        .filter(|row| !cnt.is_tracking(row))
+                        .filter_map(|row| row.first().and_then(|v| v.as_ref()))
+                        .cloned()
+                        .collect();
+
+                    d.norm_weight += nb_rows as usize;
+                    d.merge_values(&filtered_values);
+                }
+            });
+    }
+
+    pub fn from_record_batches(
+        first_batch_reader: impl FnOnce() -> Vec<ParquetRecordBatchReader>,
+        second_batch_reader: impl FnOnce() -> Vec<ParquetRecordBatchReader>,
+        combinations: Vec<ColumnsIdx>,
+        schema: Arc<Schema>,
+    ) -> anyhow::Result<Self> {
+        let comb_stat_types = Self::get_stats_types(&combinations, &schema);
+        let nb_stats = comb_stat_types.len();
+
+        // 1. FIRST PASS: hlls + mgs + null_cnts.
+        let local_partial_stats: Vec<_> = first_batch_reader()
+            .into_par_iter()
+            .map(|group| {
+                group.fold(Self::first_pass_stats_id(nb_stats), |local_stats, batch| {
+                    let mut local_stats = local_stats?;
+
+                    match batch {
+                        Ok(batch) => {
+                            let (hlls, mgs, null_cnts) = &mut local_stats;
+                            let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                            Self::generate_partial_stats(&comb, mgs, hlls, null_cnts);
+                            Ok(local_stats)
+                        }
+                        Err(e) => Err(e.into()),
+                    }
+                })
+            })
+            .collect();
+
+        let (hlls, mgs, null_cnts) = local_partial_stats.into_iter().fold(
+            Self::first_pass_stats_id(nb_stats),
+            |final_stats, local_stats| {
+                let mut final_stats = final_stats?;
+                let local_stats = local_stats?;
+
+                let (final_hlls, final_mgs, final_counts) = &mut final_stats;
+                let (local_hlls, local_mgs, local_counts) = local_stats;
+
+                for i in 0..nb_stats {
+                    final_hlls[i].merge(&local_hlls[i]);
+                    final_mgs[i].merge(&local_mgs[i]);
+                    final_counts[i] += local_counts[i];
+                }
+
+                Ok(final_stats)
+            },
+        )?;
+
+        // 2. SECOND PASS: mcv + tdigest + row_cnts.
+        let local_final_stats: Vec<_> = second_batch_reader()
+            .into_par_iter()
+            .map(|group| {
+                group.fold(
+                    Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
+                    |local_stats, batch| {
+                        let mut local_stats = local_stats?;
+
+                        match batch {
+                            Ok(batch) => {
+                                let (distrs, cnts, row_cnts) = &mut local_stats;
+                                let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                                Self::generate_full_stats(&comb, cnts, distrs, row_cnts);
+                                Ok(local_stats)
+                            }
+                            Err(e) => Err(e.into()),
+                        }
+                    },
+                )
+            })
+            .collect();
+
+        let (distrs, cnts, row_cnts) = local_final_stats.into_iter().fold(
+            Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
+            |final_stats, local_stats| {
+                let mut final_stats = final_stats?;
+                let local_stats = local_stats?;
+
+                let (final_distrs, final_cnts, final_counts) = &mut final_stats;
+                let (local_distrs, local_cnts, local_counts) = local_stats;
+
+                for i in 0..nb_stats {
+                    final_cnts[i].merge(&local_cnts[i]);
+                    if let (Some(final_distr), Some(local_distr)) =
+                        (&mut final_distrs[i], &local_distrs[i])
+                    {
+                        final_distr.merge(local_distr);
+                        final_distr.norm_weight += local_distr.norm_weight;
+                    }
+
+                    final_counts[i] += local_counts[i];
+                }
+
+                Ok(final_stats)
+            },
+        )?;
+
+        // 3. ASSEMBLE STATS.
+        let row_cnt = row_cnts[0];
+        let mut column_comb_stats = HashMap::new();
+
+        let iter_comb = comb_stat_types
+            .into_iter()
+            .map(|(comb, _, _)| comb.into_iter().map(|x| x as u64).collect())
+            .zip(cnts)
+            .zip(distrs)
+            .zip(hlls)
+            .zip(null_cnts.iter())
+            .map(|((((comb, cnt), distr), hll), null_cnt)| {
+                (
+                    comb,
+                    cnt,
+                    distr.map(Distribution::TDigest),
+                    hll,
+                    *null_cnt as f64,
+                )
+            });
+
+        for (comb, cnt, distr, hll, null_cnt) in iter_comb {
+            let column_stats = AttributeCombValueStats::new(
+                MostCommonValues::Counter(cnt),
+                distr,
+                hll.n_distinct(),
+                null_cnt / (row_cnt as f64),
+            );
+            column_comb_stats.insert(comb, column_stats);
+        }
+
+        Ok(Self {
+            row_cnt: row_cnt as u64,
+            column_comb_stats,
+        })
     }
 }
 

--- a/optd-cost-model/src/test_utils.rs
+++ b/optd-cost-model/src/test_utils.rs
@@ -1,7 +1,8 @@
 /// I thought about using the system's own parser and planner to generate these expression trees,
 /// but this is not currently feasible because it would create a cyclic dependency between
 /// optd-datafusion-bridge and optd-datafusion-repr
-#[cfg(test)]
+
+#[cfg(any(test, feature = "include-tests"))]
 pub mod tests {
     use itertools::Itertools;
     use std::{collections::HashMap, sync::Arc};
@@ -533,7 +534,7 @@ pub mod tests {
         )
     }
 
-    pub(crate) fn empty_per_attr_stats() -> TestPerAttributeStats {
+    pub fn empty_per_attr_stats() -> TestPerAttributeStats {
         TestPerAttributeStats::new(
             MostCommonValues::empty(),
             Some(Distribution::empty()),
@@ -542,7 +543,7 @@ pub mod tests {
         )
     }
 
-    pub(crate) fn per_attr_stats_with_ndistinct(ndistinct: u64) -> TestPerAttributeStats {
+    pub fn per_attr_stats_with_ndistinct(ndistinct: u64) -> TestPerAttributeStats {
         TestPerAttributeStats::new(
             MostCommonValues::empty(),
             Some(Distribution::empty()),
@@ -551,7 +552,7 @@ pub mod tests {
         )
     }
 
-    pub(crate) fn per_attr_stats_with_dist_and_ndistinct(
+    pub fn per_attr_stats_with_dist_and_ndistinct(
         dist: Vec<(Value, f64)>,
         ndistinct: u64,
     ) -> TestPerAttributeStats {

--- a/scripts/macos-postgres-setup.sh
+++ b/scripts/macos-postgres-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+rm -rf ~/pgdata
+mkdir ~/pgdata
+initdb ~/pgdata
+pg_ctl -D ~/pgdata start
+# default_user is used for cargo run --bin optd-perftest
+psql -d postgres -c "CREATE USER default_user WITH SUPERUSER PASSWORD 'password';"
+# test_user is used for cargo test --package optd-perftest
+psql -d postgres -c "CREATE USER test_user WITH SUPERUSER PASSWORD 'password';"
+# Need to apply PGtune before restarting the server. Check https://pgtune.leopard.in.ua/ for your own configuration.
+pgtune -i ~/pgdata/postgresql.conf -o ~/pgdata/postgresql.conf
+pg_ctl -D ~/pgdata restart


### PR DESCRIPTION
This PR serves as a benchmark pipeline for the cost model.

It captures the snapshot of the state of the optimizer plan before it is passed to the cost model. We take this snapshot as input, perform cardinality estimation using the new cost model we made, and compare it to Postgres' estimation.

TODO:
- [x] Add more TPC-H queries.
- [x] Generalize recursive stats computation along the plan node tree.
- [ ] Documentation.
- [ ] (optional) Run Postgres concurrently to get instant comparison. 

Credit: some code is borrowed from [optd](https://github.com/cmu-db/optd).